### PR TITLE
Add CODEOWNERS file for automatic team assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Default owners for all files in the repository
 * @conda-incubator/conda-pypi
-


### PR DESCRIPTION
This PR adds a CODEOWNERS file to automatically assign the @conda-incubator/conda-pypi team as reviewers for all pull requests in this repository.