### PR TITLE
Rename `--override-channels` to `--ignore-channels`

### DIFF
--- a/conda_pypi/cli/install.py
+++ b/conda_pypi/cli/install.py
@@ -40,7 +40,7 @@ def configure_parser(parser: _SubParsersAction) -> None:
 
         Install packages using only PyPI (skip configured conda channels)::
 
-            conda pypi install --override-channels fastapi
+            conda pypi install --ignore-channels fastapi
 
         Install packages from an alternative package index URL::
 
@@ -63,7 +63,7 @@ def configure_parser(parser: _SubParsersAction) -> None:
         epilog=epilog,
     )
     install.add_argument(
-        "--override-channels",
+        "--ignore-channels",
         action="store_true",
         help="Do not search default or .condarc channels. Will search PyPI.",
     )
@@ -123,7 +123,7 @@ def execute(args: Namespace) -> int:
 
     converter = convert_tree.ConvertTree(
         prefix_path,
-        override_channels=args.override_channels,
+        override_channels=args.ignore_channels,
         finder=finder,
     )
 
@@ -151,7 +151,7 @@ def execute(args: Namespace) -> int:
         prefix_path,
         match_specs,
         channels=[channel_url],
-        override_channels=args.override_channels,
+        override_channels=args.ignore_channels,
         yes=args.yes,
         quiet=args.quiet,
         verbosity=args.verbosity,

--- a/docs/features.md
+++ b/docs/features.md
@@ -27,7 +27,7 @@ are handled as special cases and installed directly with `pip install --no-deps`
 You can preview what would be installed without making changes using
 `--dry-run`, install packages in editable development mode with `--editable`
 or `-e`, and force dependency resolution from PyPI without using conda
-channels using `--override-channels`.
+channels using `--ignore-channels`.
 
 ### `conda pypi convert`
 
@@ -36,7 +36,7 @@ installing them, which is useful for creating conda packages from PyPI
 distributions or preparing packages for offline installation. You can specify
 where to save the converted packages using `-d`, `--dest`, or `--output-dir`.
 The command supports converting multiple packages at once and can skip conda
-channel checks entirely with `--override-channels` to convert directly from
+channel checks entirely with `--ignore-channels` to convert directly from
 PyPI.
 
 Here are some common usage patterns:
@@ -49,7 +49,7 @@ conda pypi convert httpx cowsay
 conda pypi convert -d ./my_packages httpx cowsay
 
 # Convert without checking conda channels first
-conda pypi convert --override-channels some-pypi-only-package
+conda pypi convert --ignore-channels some-pypi-only-package
 ```
 
 ## PyPI-to-Conda Conversion Engine

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -56,7 +56,7 @@ conda-pypi will analyze its dependency tree and:
   PyPI
 
 ```bash
-conda pypi install --override-channels some-package
+conda pypi install --ignore-channels some-package
 ```
 
 This forces dependency resolution to use only PyPI, bypassing conda channel

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -74,8 +74,8 @@ conda pypi install python-package-name  # instead of package-name
 
 **Solutions**:
 ```bash
-# Use --override-channels to simplify resolution
-conda pypi install --override-channels package-name
+# Use --ignore-channels to simplify resolution
+conda pypi install --ignore-channels package-name
 
 # Install dependencies from conda first
 conda install numpy pandas scipy

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -47,7 +47,7 @@ def test_index_urls(tmp_env, conda_cli, pypi_local_index):
             prefix,
             "--yes",
             "install",
-            "--override-channels",
+            "--ignore-channels",
             "--index-url",
             pypi_local_index,
             "demo-package",
@@ -64,7 +64,7 @@ def test_install_output(tmp_env, conda_cli):
             prefix,
             "--yes",
             "install",
-            "--override-channels",
+            "--ignore-channels",
             "scipy",
         )
 


### PR DESCRIPTION
The command line flag `--override-channels` is overloaded.

The conda cli uses the `--override-channels` flag along with the `--channels` flag in order to allow conda to configure channels per run. In conda, users must specify the `--channels` cli arg if the `--override-channels` arg is provided.

In conda-pypi the existing `--override-channels` flag means to ignore the configured channels and just use the local pypi package cache.

These two ideas are not the same, so they should not have the same name.

*This is required because*  if `context.channels` is called anywhere during the run of `conda pypi --override-channels ...` it will produce an error about the `--channels` flag being required. ref: https://github.com/conda/conda/blob/main/conda/base/context.py#L1006