### PR TITLE
Respect conda json output setting

### DIFF
--- a/conda_pypi/cli/install.py
+++ b/conda_pypi/cli/install.py
@@ -142,7 +142,7 @@ def execute(args: Namespace) -> int:
         for pkg in packages_to_install
         if pkg.channel.canonical_name == channel_url
     ]
-    
+
     if not context.json:
         if converted_packages:
             converted_packages_dashed = "\n - ".join(converted_packages)

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -129,4 +129,4 @@ def test_json_output(tmp_env, monkeypatch, conda_cli):
         json_actions = json.loads(out)
         assert rc == 0
         assert json_actions["prefix"] == str(prefix)
-        assert json_actions["success"] == True 
+        assert json_actions["success"]


### PR DESCRIPTION
conda-pypi should not output non-json output if the user has enabled json output. Outputting non-json output may break the ability for other programs to read the output from conda.

For example,

__previously__, conda pypi would output non json text to the terminal even if the user enables `CONDA_JSON=true` or the `--json` flag.

```
$ pixi run conda pypi --json install imagesize -p /tmp/test

Installing environment
{
  "success": true,
  "actions": {
. . .
}
```

__now__, conda pypi will not ouput non-json text to the terminal
```
$ pixi run conda pypi --json install imagesize  

{
  "success": true,
  "actions": {
. . .
}
```