### PR TITLE
Add assertions for the absence of pyc files in converted packages

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -47,3 +47,8 @@ def test_build_conda_package(
         # Ensure that the path.json file matches the packages up paths
         for path in paths_json_paths:
             assert path in included_package_paths
+
+            # Ensure that the process didn't create pyc files.
+            # This is mostly a regression test, in case "installer" was to change its behavior.
+            assert "__pycache__" not in path, "build_conda should not have created __pycache__"
+            assert not path.endswith(".pyc"), "build_conda should not have created .pyc files"


### PR DESCRIPTION
I noticed that 0.3.0 was creating pyc files in the wheel>conda conversion process while the latest commit on main doesn't. The latest commit is good. We don't want pyc files in the conda package because it's a `noarch: python` package. I think this was fixed by replacing the `pip install` with the installer library. `installer` doesn't create pyc files unless we explicitly tell it to.

So this PR only adds assertions to make sure that this doesn't regress in the future, making this an official feature instead of a "it works by accident" feature.