### PR TITLE
Update URLs from conda-incubator to conda organization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all files in the repository
-* @conda-incubator/conda-pypi
+* @conda/conda-pypi

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Better PyPI interoperability for the conda ecosystem.
 > This project is still in early stages of development. Don't use it in production (yet).
 > We do welcome feedback on what the expected behaviour should have been if something doesn't work!
 
+## Project Status
+
+This is a **community-maintained** project under the [conda](https://github.com/conda) organization.
+
+### Getting Help
+
+- **Bug reports & feature requests**: [GitHub Issues](https://github.com/conda/conda-pypi/issues)
+- **General questions**: [conda Discourse](https://conda.discourse.group/)
+- **Real-time chat**: [conda Zulip](https://conda.zulipchat.com/)
+
 ## What is this?
 
 Includes:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This is a **community-maintained** project under the [conda](https://github.com/
 ### Getting Help
 
 - **Bug reports & feature requests**: [GitHub Issues](https://github.com/conda/conda-pypi/issues)
-- **General questions**: [conda Discourse](https://conda.discourse.group/)
 - **Real-time chat**: [conda Zulip](https://conda.zulipchat.com/)
 
 ## What is this?

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/conda-incubator/conda-pypi",
+            "url": "https://github.com/conda/conda-pypi",
             "icon": "fa-brands fa-square-github",
             "type": "fontawesome",
         },
@@ -122,13 +122,13 @@ html_theme_options = {
 }
 
 html_context = {
-    "github_user": "conda-incubator",
+    "github_user": "conda",
     "github_repo": "conda-pypi",
     "github_version": "main",
     "doc_path": "docs",
 }
 
-html_baseurl = "https://conda-incubator.github.io"
+html_baseurl = "https://conda.github.io"
 
 # We don't have a locale set, so we can safely ignore that for the sitemaps.
 sitemap_locales = [None]

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -152,7 +152,7 @@ conda -vvvv pip install package-name
 If you encounter issues not covered here:
 
 1. **Check the version**: Ensure you're using the latest version of `conda-pypi`
-2. **Search existing issues**: Check the [GitHub repository](https://github.com/conda-incubator/conda-pypi) for similar problems
+2. **Search existing issues**: Check the [GitHub repository](https://github.com/conda/conda-pypi) for similar problems
 3. **Report issues**: When reporting issues please to include all the relevant details
 
 Remember that `conda-pypi` is still in early development, so feedback about unexpected behavior is valuable for improving the tool.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 
-Sitemap: https://conda-incubator.github.io/conda-pypi/sitemap.xml
+Sitemap: https://conda.github.io/conda-pypi/sitemap.xml

--- a/pixi.lock
+++ b/pixi.lock
@@ -11642,8 +11642,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-pypi
-  version: 0.3.1.dev48+ge9edf29a1.d20260128
-  sha256: a17c7b1b8f7e39a458e59a77a4f637bf8e4191b7b7cabbca0c668fb218776b01
+  version: 0.3.1.dev47+g50be0c56e
+  sha256: 8dd411c0fae5c3a27058fa5f05204c7594dfbe7ab94f2e4d13f795ac6510898d
   requires_dist:
   - build
   - conda-index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.urls]
-homepage = "https://github.com/conda-incubator/conda-pypi"
+homepage = "https://github.com/conda/conda-pypi"
 
 [project.entry-points.conda]
 conda-pypi = "conda_pypi.plugin"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,8 @@ test:
     - python -m pip install requests && exit 1 || exit 0
 
 about:
-  home: https://github.com/conda-incubator/conda-pypi
+  home: https://github.com/conda/conda-pypi
   license: MIT
   license_file: LICENSE
   summary: Better PyPI interoperability for the conda ecosystem
-  dev_url: https://github.com/conda-incubator/conda-pypi
+  dev_url: https://github.com/conda/conda-pypi


### PR DESCRIPTION
## Summary

This project has been graduated from `conda-incubator` to the main `conda` organization per the governance vote: https://github.com/conda/governance/issues/331

This PR updates all repository references from `conda-incubator/conda-pypi` to `conda/conda-pypi`, and adds required governance compliance items to the README.

## Changes

**URL updates:**
- `pyproject.toml` - homepage URL
- `recipe/meta.yaml` - home and dev_url
- `docs/conf.py` - GitHub links, html_context, html_baseurl
- `docs/robots.txt` - sitemap URL
- `docs/reference/troubleshooting.md` - GitHub repository link
- `.github/CODEOWNERS` - team reference

**Governance compliance (per [conda governance policy](https://github.com/conda/governance)):**
- `README.md` - Added maintenance status (community-maintained)
- `README.md` - Added help instructions (Issues, Discourse, Zulip)

## Test plan

- [x] Verify documentation builds correctly with new URLs
- [x] Confirm CODEOWNERS team reference is valid in the conda org