### PR TITLE
Fix benchmark task to only run benchmark-marked tests

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11642,8 +11642,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-pypi
-  version: 0.3.1.dev48+ge9edf29a1.d20260128
-  sha256: a17c7b1b8f7e39a458e59a77a4f637bf8e4191b7b7cabbca0c668fb218776b01
+  version: 0.3.1.dev46+gc524f7109.d20260129
+  sha256: 804a08688b64f3c08b096a3aed51f542b1b9e31bcaa1c17c8b133bc18150ab69
   requires_dist:
   - build
   - conda-index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ sphinx-sitemap = "*"
 
 [tool.pixi.feature.test.tasks]
 test = 'python -c "from conda_pypi.python_paths import ensure_externally_managed as e; e()" && python -mpytest -m "not benchmark"'
-benchmark= 'python -c "from conda_pypi.python_paths import ensure_externally_managed as e; e()" && python -mpytest --codspeed'
+benchmark= 'python -c "from conda_pypi.python_paths import ensure_externally_managed as e; e()" && python -mpytest -m "benchmark" --codspeed'
 pre-commit = 'pre-commit'
 
 [tool.pixi.feature.test.dependencies]


### PR DESCRIPTION
## Summary

The benchmark task was running all tests with `--codspeed` instead of only running tests marked with `@pytest.mark.benchmark`. This caused the CI to hang as it ran the full test suite during benchmark runs.

## Changes

Updated the benchmark task in `pyproject.toml` to use `-m "benchmark"` marker filter:

```diff
-benchmark= '... && python -mpytest --codspeed'
+benchmark= '... && python -mpytest -m "benchmark" --codspeed'
```

This matches the exclusion pattern used in the regular test task (`-m "not benchmark"`).

## Test plan

- [ ] CI benchmark job completes without hanging
- [ ] Only benchmark-marked tests are run during codspeed benchmarks