### PR TITLE
Allow to override built-in pypi-to-conda name mapping

### DIFF
--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -138,6 +138,7 @@ def build_conda(
     project_path: Path | None = None,
     test_dir: Path | None = None,
     is_editable=False,
+    pypi_to_conda_name_mapping: dict | None = None,
 ) -> Path:
     if not build_path.exists():
         build_path.mkdir()
@@ -146,7 +147,9 @@ def build_conda(
 
     site_packages = build_path / "site-packages"
     dist_info = next(site_packages.glob("*.dist-info"))
-    metadata = CondaMetadata.from_distribution(PathDistribution(dist_info))
+    metadata = CondaMetadata.from_distribution(
+        PathDistribution(dist_info), pypi_to_conda_name_mapping
+    )
     record = metadata.package_record.to_index_json()
     # XXX set build string as hash of pypa metadata so that conda can re-install
     # when project gains new entry-points, dependencies?
@@ -213,6 +216,7 @@ def pypa_to_conda(
     distribution="editable",
     output_path: Path | None = None,
     test_dir: Path | None = None,
+    pypi_to_conda_name_mapping: dict | None = None,
 ):
     project = Path(project)
 
@@ -239,6 +243,7 @@ def pypa_to_conda(
             project_path=project,
             test_dir=test_dir,
             is_editable=distribution == "editable",
+            pypi_to_conda_name_mapping=pypi_to_conda_name_mapping,
         )
 
     return package_conda

--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -265,6 +265,7 @@ def validate_name_mapping_format(mapping: dict) -> None:
     - A dict where keys are PyPI package names (strings)
     - Values are dicts with at least "conda_name" key (string)
     - Optionally can have "pypi_name", "import_name", "mapping_source" keys
+    - Empty dict is allowed
 
     Raises ArgumentError if format is invalid.
     """

--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -101,7 +101,9 @@ class CondaMetadata:
         }
 
     @classmethod
-    def from_distribution(cls, distribution: Distribution):
+    def from_distribution(
+        cls, distribution: Distribution, pypi_to_conda_name_mapping: dict | None = None
+    ):
         metadata = distribution.metadata
 
         python_version = metadata.get("requires-python")
@@ -146,7 +148,8 @@ class CondaMetadata:
                     about[conda_name] = urls[py_name]
 
         name = pypi_to_conda_name(
-            getattr(distribution, "name", None) or distribution.metadata.get("name")
+            getattr(distribution, "name", None) or distribution.metadata.get("name"),
+            pypi_to_conda_name_mapping,
         )
         version = getattr(distribution, "version", None) or distribution.metadata.get("version")
 
@@ -252,9 +255,13 @@ def remap_match_spec_name(match_spec: MatchSpec, name_map: Callable[[str], str])
     return MatchSpec(match_spec, name=mapped_name)
 
 
-def pypi_to_conda_name(pypi_name: str):
+def pypi_to_conda_name(pypi_name: str, pypi_to_conda_name_mapping: dict | None = None):
     pypi_name = canonicalize_name(pypi_name)
-    return grayskull_pypi_mapping.get(
+    return (
+        pypi_to_conda_name_mapping
+        if pypi_to_conda_name_mapping is not None
+        else grayskull_pypi_mapping
+    ).get(
         pypi_name,
         {
             "pypi_name": pypi_name,

--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -111,7 +111,7 @@ class CondaMetadata:
         if python_version:
             requires_python = f"python {python_version}"
 
-        requirements, extras = requires_to_conda(distribution.requires)
+        requirements, extras = requires_to_conda(distribution.requires, pypi_to_conda_name_mapping)
 
         # conda does support ~=3.0.0 "compatibility release" matches
         depends = [requires_python] + requirements
@@ -187,7 +187,9 @@ grayskull_pypi_mapping = json.loads(
 )
 
 
-def requires_to_conda(requires: Optional[List[str]]):
+def requires_to_conda(
+    requires: Optional[List[str]], pypi_to_conda_name_mapping: dict | None = None
+):
     from collections import defaultdict
 
     extras: Dict[str, List[str]] = defaultdict(list)
@@ -201,7 +203,7 @@ def requires_to_conda(requires: Optional[List[str]]):
         #     continue
 
         name = canonicalize_name(requirement.name)
-        requirement.name = pypi_to_conda_name(name)
+        requirement.name = pypi_to_conda_name(name, pypi_to_conda_name_mapping)
         as_conda = f"{requirement.name} {requirement.specifier}"
 
         if (marker := requirement.marker) is not None:

--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -257,6 +257,41 @@ def remap_match_spec_name(match_spec: MatchSpec, name_map: Callable[[str], str])
     return MatchSpec(match_spec, name=mapped_name)
 
 
+def validate_name_mapping_format(mapping: dict) -> None:
+    """
+    Validate that the name mapping dict has the correct format.
+
+    Expected format:
+    - A dict where keys are PyPI package names (strings)
+    - Values are dicts with at least "conda_name" key (string)
+    - Optionally can have "pypi_name", "import_name", "mapping_source" keys
+
+    Raises ArgumentError if format is invalid.
+    """
+    from conda.exceptions import ArgumentError
+
+    for pypi_name, value in mapping.items():
+        if not isinstance(pypi_name, str):
+            raise ArgumentError(
+                f"Name mapping keys must be strings, got {type(pypi_name).__name__} for key: {pypi_name!r}"
+            )
+
+        if not isinstance(value, dict):
+            raise ArgumentError(
+                f"Name mapping values must be dictionaries, got {type(value).__name__} for key {pypi_name!r}"
+            )
+
+        if "conda_name" not in value:
+            raise ArgumentError(
+                f"Name mapping entry for {pypi_name!r} is missing required key 'conda_name'"
+            )
+
+        if not isinstance(value["conda_name"], str):
+            raise ArgumentError(
+                f"Name mapping entry for {pypi_name!r} has invalid 'conda_name' type: expected str, got {type(value['conda_name']).__name__}"
+            )
+
+
 def pypi_to_conda_name(pypi_name: str, pypi_to_conda_name_mapping: dict | None = None):
     pypi_name = canonicalize_name(pypi_name)
     return (

--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -270,7 +270,19 @@ def validate_name_mapping_format(mapping: dict) -> None:
 
     Raises ArgumentError if format is invalid.
     """
-    for pypi_name, value in mapping.items():
+
+    # Check that mapping is a dict and has .items() method
+    if not isinstance(mapping, dict):
+        raise ArgumentError(f"Name mapping must be a dictionary, got {type(mapping).__name__}")
+
+    try:
+        items = mapping.items()
+    except AttributeError:
+        raise ArgumentError(
+            f"Name mapping must be a dictionary with .items() method, got {type(mapping).__name__}"
+        )
+
+    for pypi_name, value in items:
         if not isinstance(pypi_name, str):
             raise ArgumentError(
                 f"Name mapping keys must be strings, got {type(pypi_name).__name__} for key: {pypi_name!r}"

--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -12,6 +12,7 @@ from importlib.metadata import Distribution, PackageMetadata, PathDistribution
 from pathlib import Path
 from typing import Any, Optional, List, Dict, Callable
 
+from conda.exceptions import ArgumentError
 from conda.models.match_spec import MatchSpec
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
@@ -269,8 +270,6 @@ def validate_name_mapping_format(mapping: dict) -> None:
 
     Raises ArgumentError if format is invalid.
     """
-    from conda.exceptions import ArgumentError
-
     for pypi_name, value in mapping.items():
         if not isinstance(pypi_name, str):
             raise ArgumentError(

--- a/docs/features.md
+++ b/docs/features.md
@@ -50,6 +50,9 @@ conda pypi convert -d ./my_packages httpx cowsay
 
 # Convert without checking conda channels first
 conda pypi convert --ignore-channels some-pypi-only-package
+
+# Convert with custom name mapping
+conda pypi convert --name-mapping ./mapping.json ./my-package-1.0.0-py3-none-any.whl
 ```
 
 ## PyPI-to-Conda Conversion Engine

--- a/docs/reference/commands/convert.rst
+++ b/docs/reference/commands/convert.rst
@@ -14,8 +14,10 @@ Custom Name Mapping
 
 The ``--name-mapping`` option allows you to provide a custom JSON file that maps
 PyPI package names to conda package names. This is useful when you need to
-override the default mapping or provide mappings for packages not in the
-built-in grayskull mapping.
+replace the built-in grayskull mapping with your own mapping file.
+
+When ``--name-mapping`` is provided, the built-in mapping is not used for that
+conversion. The JSON file is treated as the complete mapping source.
 
 The mapping file should be a JSON object where:
 

--- a/docs/reference/commands/convert.rst
+++ b/docs/reference/commands/convert.rst
@@ -8,3 +8,42 @@
    :path: convert
    :nodefault:
    :nodefaultconst:
+
+Custom Name Mapping
+===================
+
+The ``--name-mapping`` option allows you to provide a custom JSON file that maps
+PyPI package names to conda package names. This is useful when you need to
+override the default mapping or provide mappings for packages not in the
+built-in grayskull mapping.
+
+The mapping file should be a JSON object where:
+
+- Keys are PyPI package names (canonicalized, lowercase)
+- Values are dictionaries with at least a ``conda_name`` key (string)
+- Optionally can include ``pypi_name``, ``import_name``, and ``mapping_source`` keys
+
+Example mapping file (``mapping.json``):
+
+.. code-block:: json
+
+   {
+     "requests": {
+       "pypi_name": "requests",
+       "conda_name": "requests",
+       "import_name": "requests",
+       "mapping_source": "custom"
+     },
+     "my-package": {
+       "conda_name": "my-package-conda"
+     }
+   }
+
+Usage example:
+
+.. code-block:: bash
+
+   conda pypi convert --name-mapping ./mapping.json ./my-package-1.0.0-py3-none-any.whl
+
+The mapping will be used during conversion to determine the conda package name
+for dependencies and the main package being converted.

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -1,8 +1,11 @@
+import json
 import os
+from pathlib import Path
 
 import pytest
 from conda.cli.main import main_subshell
 from conda.common.compat import on_win
+from conda.exceptions import ArgumentError
 import conda_package_streaming.package_streaming as cps
 
 # Test input paths
@@ -159,4 +162,142 @@ def test_convert_with_test_dir_missing_run_test(tmp_path):
     ]
 
     with pytest.raises(ValueError, match="Test directory must contain at least one run_test"):
+        main_subshell(*args)
+
+
+def test_convert_with_name_mapping_empty(tmp_path):
+    """Test that empty mapping is allowed."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    # Create empty mapping file
+    mapping_file = tmp_path / "mapping.json"
+    mapping_file.write_text("{}")
+
+    wheel_path = "tests/pypi_local_index/demo-package/demo_package-0.1.0-py3-none-any.whl"
+    args = [
+        "pypi",
+        "convert",
+        "--output-folder",
+        str(out_dir),
+        "--name-mapping",
+        str(mapping_file),
+        wheel_path,
+    ]
+
+    # Should not raise
+    main_subshell(*args)
+
+    files = list(out_dir.glob("*.conda"))
+    assert files, f"No .conda artifacts found in {out_dir}"
+    assert files[0].is_file()
+
+
+def test_convert_with_name_mapping_invalid_format_missing_conda_name(tmp_path):
+    """Test that mapping missing conda_name raises ArgumentError."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    # Create invalid mapping file (missing conda_name)
+    mapping_file = tmp_path / "mapping.json"
+    mapping_file.write_text('{"requests": {"pypi_name": "requests"}}')
+
+    wheel_path = "tests/pypi_local_index/demo-package/demo_package-0.1.0-py3-none-any.whl"
+    args = [
+        "pypi",
+        "convert",
+        "--output-folder",
+        str(out_dir),
+        "--name-mapping",
+        str(mapping_file),
+        wheel_path,
+    ]
+
+    with pytest.raises(ArgumentError, match="missing required key 'conda_name'"):
+        main_subshell(*args)
+
+
+def test_convert_with_name_mapping_invalid_format_non_string_conda_name(tmp_path):
+    """Test that non-string conda_name raises ArgumentError."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    # Create invalid mapping file (conda_name is not a string)
+    mapping_file = tmp_path / "mapping.json"
+    mapping_file.write_text('{"requests": {"conda_name": 123}}')
+
+    wheel_path = "tests/pypi_local_index/demo-package/demo_package-0.1.0-py3-none-any.whl"
+    args = [
+        "pypi",
+        "convert",
+        "--output-folder",
+        str(out_dir),
+        "--name-mapping",
+        str(mapping_file),
+        wheel_path,
+    ]
+
+    with pytest.raises(ArgumentError, match="invalid 'conda_name' type"):
+        main_subshell(*args)
+
+
+def test_convert_with_name_mapping_valid(tmp_path):
+    """Test that valid mapping file works correctly and mapping is applied."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    # Create valid mapping file
+    mapping_file = tmp_path / "mapping.json"
+    valid_mapping = {
+        "demo-package": {
+            "pypi_name": "demo-package",
+            "conda_name": "demo-package-mapped",
+            "import_name": "demo_package",
+            "mapping_source": "test",
+        }
+    }
+    mapping_file.write_text(json.dumps(valid_mapping))
+
+    wheel_path = "tests/pypi_local_index/demo-package/demo_package-0.1.0-py3-none-any.whl"
+    args = [
+        "pypi",
+        "convert",
+        "--output-folder",
+        str(out_dir),
+        "--name-mapping",
+        str(mapping_file),
+        wheel_path,
+    ]
+
+    # Should not raise
+    main_subshell(*args)
+
+    files = list(out_dir.glob("*.conda"))
+    assert files, f"No .conda artifacts found in {out_dir}"
+    assert files[0].is_file()
+    assert os.path.getsize(files[0]) > 0
+    # Verify that mapping was applied - package name should be "demo-package-mapped"
+    assert "demo-package-mapped" in files[0].name, (
+        f"Expected 'demo-package-mapped' in filename {files[0].name}, but mapping was not applied"
+    )
+
+
+def test_convert_with_name_mapping_nonexistent_file(tmp_path):
+    """Test that nonexistent mapping file raises ArgumentError."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    mapping_file = tmp_path / "nonexistent.json"
+    wheel_path = "tests/pypi_local_index/demo-package/demo_package-0.1.0-py3-none-any.whl"
+    args = [
+        "pypi",
+        "convert",
+        "--output-folder",
+        str(out_dir),
+        "--name-mapping",
+        str(mapping_file),
+        wheel_path,
+    ]
+
+    with pytest.raises(ArgumentError, match="Could not open"):
         main_subshell(*args)

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -1,6 +1,5 @@
 import json
 import os
-from pathlib import Path
 
 import pytest
 from conda.cli.main import main_subshell

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -192,6 +192,30 @@ def test_convert_with_name_mapping_empty(tmp_path):
     assert files[0].is_file()
 
 
+def test_convert_with_name_mapping_not_dict(tmp_path):
+    """Test that non-dict JSON raises ArgumentError."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    # Create invalid mapping file (list instead of dict)
+    mapping_file = tmp_path / "mapping.json"
+    mapping_file.write_text('["not", "a", "dict"]')
+
+    wheel_path = "tests/pypi_local_index/demo-package/demo_package-0.1.0-py3-none-any.whl"
+    args = [
+        "pypi",
+        "convert",
+        "--output-folder",
+        str(out_dir),
+        "--name-mapping",
+        str(mapping_file),
+        wheel_path,
+    ]
+
+    with pytest.raises(ArgumentError, match="must be a dictionary"):
+        main_subshell(*args)
+
+
 def test_convert_with_name_mapping_invalid_format_missing_conda_name(tmp_path):
     """Test that mapping missing conda_name raises ArgumentError."""
     out_dir = tmp_path / "out"

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,0 +1,77 @@
+"""Tests for conda_pypi.translate module."""
+
+import pytest
+from conda.exceptions import ArgumentError
+
+from conda_pypi.translate import validate_name_mapping_format
+
+
+def test_validate_name_mapping_format_valid():
+    """Test that valid mapping format passes validation."""
+    valid_mapping = {
+        "requests": {
+            "pypi_name": "requests",
+            "conda_name": "requests",
+            "import_name": "requests",
+            "mapping_source": "regro-bot",
+        },
+        "numpy": {
+            "conda_name": "numpy",
+        },
+    }
+    # Should not raise
+    validate_name_mapping_format(valid_mapping)
+
+
+def test_validate_name_mapping_format_empty():
+    """Test that empty dict is allowed."""
+    # Should not raise
+    validate_name_mapping_format({})
+
+
+def test_validate_name_mapping_format_non_string_key():
+    """Test that non-string keys raise ArgumentError."""
+    with pytest.raises(ArgumentError, match="keys must be strings"):
+        validate_name_mapping_format({123: {"conda_name": "test"}})
+
+    with pytest.raises(ArgumentError, match="keys must be strings"):
+        validate_name_mapping_format({None: {"conda_name": "test"}})
+
+
+def test_validate_name_mapping_format_non_dict_value():
+    """Test that non-dict values raise ArgumentError."""
+    with pytest.raises(ArgumentError, match="must be dictionaries"):
+        validate_name_mapping_format({"requests": "not a dict"})
+
+    with pytest.raises(ArgumentError, match="must be dictionaries"):
+        validate_name_mapping_format({"requests": []})
+
+
+def test_validate_name_mapping_format_missing_conda_name():
+    """Test that missing conda_name key raises ArgumentError."""
+    with pytest.raises(ArgumentError, match="missing required key 'conda_name'"):
+        validate_name_mapping_format({"requests": {"pypi_name": "requests"}})
+
+    with pytest.raises(ArgumentError, match="missing required key 'conda_name'"):
+        validate_name_mapping_format({"requests": {}})
+
+
+def test_validate_name_mapping_format_non_string_conda_name():
+    """Test that non-string conda_name raises ArgumentError."""
+    with pytest.raises(ArgumentError, match="invalid 'conda_name' type"):
+        validate_name_mapping_format({"requests": {"conda_name": 123}})
+
+    with pytest.raises(ArgumentError, match="invalid 'conda_name' type"):
+        validate_name_mapping_format({"requests": {"conda_name": None}})
+
+    with pytest.raises(ArgumentError, match="invalid 'conda_name' type"):
+        validate_name_mapping_format({"requests": {"conda_name": []}})
+
+
+def test_validate_name_mapping_format_multiple_errors():
+    """Test that validation catches first error."""
+    # First error: non-string key
+    with pytest.raises(ArgumentError, match="keys must be strings"):
+        validate_name_mapping_format(
+            {123: {"conda_name": "test"}, "valid": {"conda_name": "test"}}
+        )

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -29,6 +29,25 @@ def test_validate_name_mapping_format_empty():
     validate_name_mapping_format({})
 
 
+def test_validate_name_mapping_format_not_dict():
+    """Test that non-dict raises ArgumentError."""
+    with pytest.raises(ArgumentError, match="must be a dictionary"):
+        validate_name_mapping_format([])
+
+    with pytest.raises(ArgumentError, match="must be a dictionary"):
+        validate_name_mapping_format("not a dict")
+
+    with pytest.raises(ArgumentError, match="must be a dictionary"):
+        validate_name_mapping_format(None)
+
+    # Test that objects without .items() method raise ArgumentError
+    class NoItems:
+        pass
+
+    with pytest.raises(ArgumentError, match="must be a dictionary"):
+        validate_name_mapping_format(NoItems())
+
+
 def test_validate_name_mapping_format_non_string_key():
     """Test that non-string keys raise ArgumentError."""
     with pytest.raises(ArgumentError, match="keys must be strings"):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This closes #252 
Adds a `--name-mapping` option to use a custom `.json` file instead of the built-in `grayskull_pypi_mapping.json`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

~~- [ ] Add / update necessary tests?~~
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
