### PR TITLE
Fix analyze step stuck with no code changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,6 @@ on:
     tags:
       - "*"
   pull_request:
-    paths:
-      - ".github/workflows/test.yml"
-      - "conda_pypi/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - "pixi.lock"
 
 concurrency:
   # Concurrency group that uses the workflow name and PR number if available
@@ -23,7 +17,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # detect whether any code changes are included in this PR
+  changes:
+    if: github.event_name == 'pull_request'
+
+    runs-on: ubuntu-slim
+    permissions:
+      # necessary to detect changes
+      # https://github.com/dorny/paths-filter#supported-workflows
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Filter Changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - '.github/workflows/test.yml'
+              - 'conda_pypi/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'pixi.lock'
+
   tests:
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request'
+      || needs.changes.outputs.code == 'true'
     name: ${{ matrix.os }}, ${{ matrix.pixi-env }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -63,6 +85,10 @@ jobs:
         run: pixi run --environment ${{ env.PIXI_ENV_NAME }} test --basetemp=${{ runner.os == 'Windows' && 'D:\\temp' || runner.temp }} -vv
 
   linux-benchmarks:
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request'
+      || needs.changes.outputs.code == 'true'
     name: benchmarks py${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
@@ -107,4 +133,5 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         id: alls-green
         with:
+          allowed-skips: ${{ toJSON(needs) }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I noticed that PRs #260 and #262 were stuck on the analyze step. We were filtering on paths to not rerun all the tests, but then the analyze step was getting stuck. This PR uses the solution from the conda repo to filter changes using the dorny/paths-filter action. This will allow the analyze run to see the other jobs passed as allowed-skips.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
