### PR TITLE
Refactor dependency installation in build.py

### DIFF
--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -5,7 +5,6 @@ Create wheels from pypa projects.
 """
 
 import csv
-import itertools
 import json
 import logging
 import os
@@ -86,10 +85,6 @@ def json_dumps(object):
     Consistent json formatting.
     """
     return json.dumps(object, indent=2, sort_keys=True)
-
-
-def flatten(iterable):
-    return [*itertools.chain(*iterable)]
 
 
 def build_pypa(

--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -112,7 +112,7 @@ def build_pypa(
         """
         for _retry in range(2):
             try:
-                missing = dependencies.check_dependencies(requirements, prefix=prefix)
+                dependencies.check_dependencies(requirements, prefix=prefix)
                 break
             except dependencies.MissingDependencyError as e:
                 dependencies.ensure_requirements(e.dependencies, prefix=prefix)

--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -107,22 +107,25 @@ def build_pypa(
     python_executable = str(paths.get_python_executable(prefix))
 
     builder = ProjectBuilder(path, python_executable=python_executable)
+    
+    def install_missing(requirements):
+        """
+        Check if requirements are missing. If so, invoke conda to install into target prefix.
+        """
+        for _retry in range(2):
+            try:
+                missing = dependencies.check_dependencies(requirements, prefix=prefix)
+                break
+            except dependencies.MissingDependencyError as e:
+                dependencies.ensure_requirements(e.dependencies, prefix=prefix)
 
     build_system_requires = builder.build_system_requires
-    for _retry in range(2):
-        try:
-            missing = dependencies.check_dependencies(build_system_requires, prefix=prefix)
-            break
-        except dependencies.MissingDependencyError as e:
-            dependencies.ensure_requirements(e.dependencies, prefix=prefix)
-
-    log.debug(f"Installing requirements for build system: {missing}")
-    # does flatten() work for a deeper dependency chain?
-    dependencies.ensure_requirements(flatten(missing), prefix=prefix)
-
-    requirements = builder.check_dependencies(distribution)
+    log.debug(f"Ensure requirements for build system: {build_system_requires}")    
+    install_missing(flatten(build_system_requires))
+    
+    requirements = builder.get_requires_for_build(distribution)
     log.debug(f"Additional requirements for {distribution}: {requirements}")
-    dependencies.ensure_requirements(flatten(requirements), prefix=prefix)
+    install_missing(flatten(requirements))
 
     editable_file = builder.build(distribution, output_path)
     log.debug(f"The wheel is at {editable_file}")

--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -112,7 +112,10 @@ def build_pypa(
         """
         for _retry in range(2):
             try:
-                dependencies.check_dependencies(requirements, prefix=prefix)
+                missing = dependencies.check_dependencies(requirements, prefix=prefix)
+                if missing:
+                    dependencies.ensure_requirements(missing, prefix=prefix)
+                    continue
                 break
             except dependencies.MissingDependencyError as e:
                 dependencies.ensure_requirements(e.dependencies, prefix=prefix)

--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -7,26 +7,24 @@ Create wheels from pypa projects.
 import csv
 import itertools
 import json
+import logging
 import os
+import shutil
 import sys
 import tempfile
-import shutil
 from importlib.metadata import PathDistribution
 from pathlib import Path
 from typing import Union
-import logging
-
-from conda_package_streaming.create import conda_builder
-from conda.common.path.windows import win_path_to_unix
-from conda.common.compat import on_win
 
 from build import ProjectBuilder
+from conda.common.compat import on_win
+from conda.common.path.windows import win_path_to_unix
+from conda_package_streaming.create import conda_builder
 
 from conda_pypi import dependencies, installer, paths
 from conda_pypi.conda_build_utils import PathType, sha256_checksum
 from conda_pypi.translate import CondaMetadata
 from conda_pypi.utils import sha256_as_base64url
-
 
 log = logging.getLogger(__name__)
 
@@ -107,7 +105,7 @@ def build_pypa(
     python_executable = str(paths.get_python_executable(prefix))
 
     builder = ProjectBuilder(path, python_executable=python_executable)
-    
+
     def install_missing(requirements):
         """
         Check if requirements are missing. If so, invoke conda to install into target prefix.
@@ -120,12 +118,12 @@ def build_pypa(
                 dependencies.ensure_requirements(e.dependencies, prefix=prefix)
 
     build_system_requires = builder.build_system_requires
-    log.debug(f"Ensure requirements for build system: {build_system_requires}")    
-    install_missing(flatten(build_system_requires))
-    
+    log.debug(f"Ensure requirements for build system: {build_system_requires}")
+    install_missing(build_system_requires)
+
     requirements = builder.get_requires_for_build(distribution)
     log.debug(f"Additional requirements for {distribution}: {requirements}")
-    install_missing(flatten(requirements))
+    install_missing(requirements)
 
     editable_file = builder.build(distribution, output_path)
     log.debug(f"The wheel is at {editable_file}")

--- a/conda_pypi/dependencies/pypi.py
+++ b/conda_pypi/dependencies/pypi.py
@@ -7,7 +7,7 @@ import importlib.resources
 import json
 import subprocess
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable
 
 from conda.cli.main import main_subshell
 
@@ -20,7 +20,7 @@ class MissingDependencyError(Exception):
     When the dependency subprocess can't run.
     """
 
-    def __init__(self, dependencies: List[str]):
+    def __init__(self, dependencies: list[str]):
         self.dependencies = dependencies
 
 
@@ -43,7 +43,13 @@ def check_dependencies(requirements: Iterable[str], prefix: Path):
             capture_output=True,
             check=True,
         )
-        missing = json.loads(result.stdout)
+        missing_raw = json.loads(result.stdout)
+        missing = []
+        for requirement in missing_raw:
+            if isinstance(requirement, str):
+                missing.append(requirement)
+            elif isinstance(requirement, list) and requirement:
+                missing.append(requirement[-1])
     except subprocess.CalledProcessError as e:
         if (
             "ModuleNotFound" in e.stderr
@@ -55,7 +61,7 @@ def check_dependencies(requirements: Iterable[str], prefix: Path):
     return missing
 
 
-def ensure_requirements(requirements: List[str], prefix: Path):
+def ensure_requirements(requirements: list[str], prefix: Path):
     if requirements:
         conda_requirements, _ = requires_to_conda(requirements)
         # -y may be appropriate during tests only

--- a/news/281-build-requires
+++ b/news/281-build-requires
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Improve missing dependency `builder.get_requires_for_build(distribution)`
+  detection, installation when building Python packages. (#281)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pixi.lock
+++ b/pixi.lock
@@ -14802,8 +14802,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-pypi
-  version: 0.5.1.dev8+ga3c30110b
-  sha256: 6d3ed2a889f758babd17b4e920ada18bf87324809bf242899c42c6c856f536d3
+  version: 0.5.1.dev20+gfc6e7445c
+  sha256: b41eb3caf6ae1dbceb9d1a44a96c6764a1790a2181fd7553ffa3c9aeff900da4
   requires_dist:
   - build
   - conda-index>=0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.26", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -11,7 +11,7 @@ from packaging.requirements import InvalidRequirement
 import build
 import conda_pypi.dependencies_subprocess
 from conda_pypi.build import filter, pypa_to_conda
-from conda_pypi.dependencies.pypi import ensure_requirements
+from conda_pypi.dependencies.pypi import check_dependencies, ensure_requirements
 
 
 def test_editable(tmp_path):
@@ -80,6 +80,18 @@ def test_ensure_requirements(mocker):
     ensure_requirements(["flit_core"], prefix=Path())
     # normalizes/converts the underscore flit_core->flit-core
     assert mock.call_args.args == ("install", "--prefix", ".", "-y", "flit-core")
+
+
+def test_check_dependencies_flattens_missing_dependencies(mocker):
+    mocker.patch("conda_pypi.dependencies.pypi.paths.get_python_executable", return_value=Path())
+    subprocess_run = mocker.patch("conda_pypi.dependencies.pypi.subprocess.run")
+    subprocess_run.return_value.stdout = json.dumps(
+        [["hatchling>=1.26"], ["setuptools>=65", "packaging>=23"]]
+    )
+
+    missing = check_dependencies(["hatchling>=1.26", "setuptools>=65"], prefix=Path())
+
+    assert missing == ["hatchling>=1.26", "packaging>=23"]
 
 
 def test_filter_coverage():


### PR DESCRIPTION

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

A bug caused pypa/build to look for build requirements in the base conda environment. This would cause e.g. an editable install that requires `hatchling` to fail if `hatchling` was installed in the base environment. conda-pypi thinks it is available, but when it runs the project's build in the target environment it is not available. If e.g. `hatchling` was not installed in the base environment, then conda-pypi appears to work and installs it in the target environment.

Update handling to detect whether the "editable" requirements (or others) exist in the target prefix, not in the prefix that conda itself runs in.

Fix #281 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
