### PR TITLE
Docs: Remove unsupported git+ syntax

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -34,7 +34,7 @@ Environment Validation
          ↓
 Package Classification
          ↓
-    VCS/Editable? ----Yes---→ Direct pip install --> Deploy EXTERNALLY-MANAGED
+    Editable (-e)? ----Yes---→ Build local project to .conda --> Install --> Deploy EXTERNALLY-MANAGED
          ↓ No
 Dependency Resolution
          ↓

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,10 +19,11 @@ conda-first approach. If a dependency is available on conda channels, it will
 be installed with `conda` directly. If not available on conda channels, the
 dependency will be converted from PyPI to `.conda` format.
 
-The system uses multiple sources for package name mapping which are
-currently hardcoded.  In the future, it will use other means to have
-a more active way to get current name mappings. VCS and editable packages
-are handled as special cases and installed directly with `pip install --no-deps`.
+PyPI names are mapped to conda names with a bundled Grayskull table, plus a
+simple normalization rule when a package is not listed. `conda pypi convert`
+can load a replacement table from a JSON file via `--name-mapping`. With
+`-e` / `--editable`, a local project directory is built into a `.conda`
+package and installed.
 
 You can preview what would be installed without making changes using
 `--dry-run`, install packages in editable development mode with `--editable`
@@ -99,28 +100,21 @@ In the PyPA grammar, extras are a comma-separated list of names. Multiple extras
 
 ## Editable Package Support
 
-`conda-pypi` provides comprehensive support for editable (development)
-installations, making it ideal for development environments where code is
-frequently modified. The system supports both version control system packages
-and local packages.
+`conda-pypi` supports editable (development) installs for local project
+directories: the project is built into a `.conda` package and installed into
+the environment. This is intended for workflows where you edit code in a
+checkout on disk.
 
-For VCS packages, you can install directly from git URLs with automatic
-cloning. The system caches VCS repositories locally for improved performance
-and manages temporary directories and repository clones automatically. Local
-package support allows you to install packages from local project directories
-in editable mode, which is perfect for active development workflows.
+Pip-style VCS requirement URLs are not yet supported.
 
 Here are some common usage patterns for editable installations:
 
 ```bash
-# Install from git repository in editable mode
-conda pypi install -e git+https://github.com/user/project.git
-
 # Install local project in editable mode
 conda pypi install -e ./my-project/
 
-# Multiple editable packages
-conda pypi install -e ./package1/ -e git+https://github.com/user/package2.git
+# Multiple local editable packages
+conda pypi install -e ./package1/ -e ./package2/
 ```
 
 ## `conda env` integrations

--- a/docs/features.md
+++ b/docs/features.md
@@ -105,7 +105,6 @@ directories: the project is built into a `.conda` package and installed into
 the environment. This is intended for workflows where you edit code in a
 checkout on disk.
 
-Pip-style VCS requirement URLs are not yet supported.
 
 Here are some common usage patterns for editable installations:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,9 +14,8 @@ them. The smart installation strategy ensures that explicitly requested
 packages come from PyPI while dependencies are sourced from conda channels
 when available.
 
-`conda-pypi` includes full support for development workflows through
-editable installations with the `-e` flag, and can install directly from git
-repositories and local directories. To protect your conda environments, it
+`conda-pypi` includes support for development workflows through editable
+installations with the `-e` flag for local project directories. To protect your conda environments, it
 automatically deploys `EXTERNALLY-MANAGED` files to prevent accidental pip
 usage that could break your environment's integrity.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,11 @@ packages come from PyPI while dependencies are sourced from conda channels
 when available.
 
 `conda-pypi` includes support for development workflows through editable
-installations with the `-e` flag for local project directories. To protect your conda environments, it
-automatically deploys `EXTERNALLY-MANAGED` files to prevent accidental pip
-usage that could break your environment's integrity.
+installations with the `-e` flag for local project directories.
+
+`conda-pypi` also installs `EXTERNALLY-MANAGED` marker files when you install
+the plugin, discouraging direct `pip` use that can destabilize conda-managed
+environments.
 
 :::{warning}
 This project is still in early stages of development. Don't use it in

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -87,9 +87,6 @@ preparing packages for offline installation.
 # Install local project in editable mode
 conda pypi install -e ./my-project/
 
-# Install from version control in editable mode
-conda pypi install -e git+https://github.com/user/project.git
-
 # Preview what would be installed
 conda pypi install --dry-run niquests pandas
 ```

--- a/news/295-docs-remove-editable-vcs-install
+++ b/news/295-docs-remove-editable-vcs-install
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Clarify that `conda pypi install -e` is for local project paths only, not pip-style VCS requirement URLs. (#295)
+
+### Other
+
+* Drop skipped tests that targeted `git+https` editable installs. (#295)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
 import pytest
 from conda.testing.fixtures import TmpEnvFixture, CondaCLIFixture
-
-from conda_pypi.python_paths import get_env_site_packages
 
 
 def test_conda_pypi_install_basic(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture):
@@ -140,61 +137,3 @@ def test_pyqt(
         assert requested_conda_spec in out
         for conda_spec in installed_conda_specs:
             assert conda_spec in out
-
-
-@pytest.mark.skip(reason="Migrating to alternative install method using conda pupa")
-@pytest.mark.parametrize(
-    "requirement,name",
-    [
-        pytest.param(
-            # pure Python
-            "git+https://github.com/dateutil/dateutil.git@2.9.0.post0",
-            "python_dateutil",
-            marks=pytest.mark.skip(reason="Fragile test with git repo state issues"),
-        ),
-        pytest.param(
-            # compiled bits
-            "git+https://github.com/yaml/pyyaml.git@6.0.1",
-            "PyYAML",
-            marks=pytest.mark.skip(reason="Editable install path detection issues"),
-        ),
-        pytest.param(
-            # has conda dependencies
-            "git+https://github.com/python-poetry/cleo.git@2.1.0",
-            "cleo",
-        ),
-    ],
-)
-def test_editable_installs(
-    tmp_path: Path, tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture, requirement, name
-):
-    os.chdir(tmp_path)
-    with tmp_env("python=3.9", "pip") as prefix:
-        out, err, rc = conda_cli(
-            "pypi",
-            "-p",
-            prefix,
-            "--yes",
-            "install",
-            "-e",
-            f"{requirement}#egg={name}",
-        )
-        assert rc == 0
-        sp = get_env_site_packages(prefix)
-        editable_pth = list(sp.glob(f"__editable__.{name}-*.pth"))  # Modern pip format
-        if not editable_pth:
-            editable_pth = list(sp.glob(f"{name}.pth"))  # Older format
-
-        assert len(editable_pth) == 1, (
-            f"Expected 1 editable .pth file for {name}, found: {editable_pth}"
-        )
-        pth_contents = editable_pth[0].read_text().strip()
-        src_path = tmp_path / "src"
-
-        if not pth_contents.startswith(f"import __editable___{name}"):
-            pth_path = Path(pth_contents)
-            assert (
-                src_path in pth_path.parents
-                or src_path == pth_path
-                or pth_path.is_relative_to(src_path)
-            ), f"Expected {src_path} to be a parent of or equal to {pth_path}"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

As @dholth pointed out, conda-pypi doesn't currently support editable installs from VCS like `conda pypi install -e git+https://example.com/repo/project`. This PR removes mention of it from the docs and removes a skipped test. In the future we can consider adding back this feature.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
