### PR TITLE
Fix license location

### DIFF
--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -27,6 +27,101 @@ from conda_pypi.utils import sha256_as_base64url
 
 log = logging.getLogger(__name__)
 
+# Common license file patterns for fallback detection.
+# Based on common conventions and wheel/setuptools defaults.
+LICENSE_PATTERNS = (
+    "LICENSE",
+    "LICENCE",
+    "COPYING",
+    "NOTICE",
+    "AUTHORS",
+)
+LICENSE_EXTENSIONS = ("", ".txt", ".md", ".rst")
+
+
+def get_license_files(dist_info: Path) -> list[Path]:
+    """
+    Find license files from a wheel's dist-info directory.
+
+    Reads License-File entries from METADATA (PEP 639). If none are found,
+    falls back to searching for common license file patterns.
+
+    Args:
+        dist_info: Path to the *.dist-info directory.
+
+    Returns:
+        List of paths to license files found.
+    """
+    license_files: list[Path] = []
+
+    # Read License-File entries from METADATA (PEP 639)
+    metadata_path = dist_info / "METADATA"
+    if metadata_path.exists():
+        for line in metadata_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("License-File:"):
+                filename = line.split(":", 1)[1].strip()
+                # PEP 639: files are in dist-info/licenses/ subdirectory
+                license_path = dist_info / "licenses" / filename
+                if license_path.exists():
+                    license_files.append(license_path)
+                else:
+                    # Older wheels may have license at dist-info/<filename>
+                    license_path = dist_info / filename
+                    if license_path.exists():
+                        license_files.append(license_path)
+                    else:
+                        log.warning(f"License-File '{filename}' not found in {dist_info}")
+
+    # Fallback: search for common license patterns if no License-File entries
+    if not license_files:
+        # Check dist-info/licenses/ directory
+        licenses_dir = dist_info / "licenses"
+        if licenses_dir.is_dir():
+            for f in licenses_dir.iterdir():
+                if f.is_file():
+                    license_files.append(f)
+
+        # Check dist-info/ for common license patterns
+        if not license_files:
+            for pattern in LICENSE_PATTERNS:
+                for ext in LICENSE_EXTENSIONS:
+                    candidate = dist_info / f"{pattern}{ext}"
+                    if candidate.exists():
+                        license_files.append(candidate)
+
+    return license_files
+
+
+def copy_licenses_to_info(dist_info: Path, info_path: Path) -> list[str]:
+    """
+    Copy license files from wheel dist-info to conda info/licenses/.
+
+    Per CEP 34, info/licenses/ is the canonical location for license files
+    in conda packages.
+
+    Args:
+        dist_info: Path to the *.dist-info directory.
+        info_path: Path to the conda package's info/ directory.
+
+    Returns:
+        List of license filenames copied.
+    """
+    license_files = get_license_files(dist_info)
+    if not license_files:
+        return []
+
+    licenses_dir = info_path / "licenses"
+    licenses_dir.mkdir(exist_ok=True)
+
+    copied = []
+    for license_file in license_files:
+        dest = licenses_dir / license_file.name
+        shutil.copy2(license_file, dest)
+        copied.append(license_file.name)
+        log.debug(f"Copied license file: {license_file.name}")
+
+    return copied
+
 
 def filter(tarinfo):
     """
@@ -162,6 +257,9 @@ def build_conda(
     # used especially for console_scripts
     if link_json := metadata.link_json():
         (build_path / "info" / "link.json").write_text(json_dumps(link_json))
+
+    # Copy license files to info/licenses/ per CEP 34
+    copy_licenses_to_info(dist_info, build_path / "info")
 
     # Allow pip to list us as editable or show the path to our project.
     # XXX leaks path

--- a/news/fix-license-location
+++ b/news/fix-license-location
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Copy license files to `info/licenses/` per CEP 34 when building conda packages from wheels. (#TBD)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_license_files.py
+++ b/tests/test_license_files.py
@@ -1,0 +1,169 @@
+"""Tests for license file handling in conda package builds."""
+
+from pathlib import Path
+
+from conda_pypi.build import get_license_files, copy_licenses_to_info
+
+
+class TestGetLicenseFiles:
+    """Tests for get_license_files() function."""
+
+    def test_with_license_file_metadata_pep639(self, tmp_path: Path):
+        """License-File entries in METADATA point to dist-info/licenses/ (PEP 639)."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\n"
+            "Name: pkg\n"
+            "Version: 1.0\n"
+            "License-File: LICENSE\n"
+            "License-File: NOTICE\n"
+        )
+        licenses_dir = dist_info / "licenses"
+        licenses_dir.mkdir()
+        (licenses_dir / "LICENSE").write_text("MIT License")
+        (licenses_dir / "NOTICE").write_text("Copyright notice")
+
+        result = get_license_files(dist_info)
+
+        assert len(result) == 2
+        assert {f.name for f in result} == {"LICENSE", "NOTICE"}
+
+    def test_with_license_file_metadata_old_layout(self, tmp_path: Path):
+        """License-File entries point directly to dist-info/ (older wheels)."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nLicense-File: LICENSE.txt\n"
+        )
+        (dist_info / "LICENSE.txt").write_text("BSD License")
+
+        result = get_license_files(dist_info)
+
+        assert len(result) == 1
+        assert result[0].name == "LICENSE.txt"
+
+    def test_fallback_to_licenses_dir(self, tmp_path: Path):
+        """When no License-File in METADATA, check dist-info/licenses/."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n")
+        licenses_dir = dist_info / "licenses"
+        licenses_dir.mkdir()
+        (licenses_dir / "LICENSE").write_text("Apache License")
+
+        result = get_license_files(dist_info)
+
+        assert len(result) == 1
+        assert result[0].name == "LICENSE"
+
+    def test_fallback_to_common_patterns(self, tmp_path: Path):
+        """When no License-File or licenses dir, search for common patterns."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n")
+        (dist_info / "LICENSE").write_text("GPL License")
+        (dist_info / "COPYING.txt").write_text("Copying info")
+
+        result = get_license_files(dist_info)
+
+        assert len(result) == 2
+        assert {f.name for f in result} == {"LICENSE", "COPYING.txt"}
+
+    def test_no_license_files_found(self, tmp_path: Path):
+        """Returns empty list when no license files exist."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n")
+
+        result = get_license_files(dist_info)
+
+        assert result == []
+
+    def test_missing_license_file_logs_warning(self, tmp_path: Path, caplog):
+        """Logs warning when License-File entry points to missing file."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nLicense-File: MISSING_LICENSE\n"
+        )
+
+        result = get_license_files(dist_info)
+
+        assert result == []
+        assert "MISSING_LICENSE" in caplog.text
+        assert "not found" in caplog.text
+
+
+class TestCopyLicensesToInfo:
+    """Tests for copy_licenses_to_info() function."""
+
+    def test_copies_license_files_to_info_licenses(self, tmp_path: Path):
+        """License files are copied to info/licenses/ per CEP 34."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\nLicense-File: LICENSE\n"
+        )
+        licenses_dir = dist_info / "licenses"
+        licenses_dir.mkdir()
+        (licenses_dir / "LICENSE").write_text("MIT License content")
+
+        info_path = tmp_path / "info"
+        info_path.mkdir()
+
+        copied = copy_licenses_to_info(dist_info, info_path)
+
+        assert copied == ["LICENSE"]
+        assert (info_path / "licenses" / "LICENSE").exists()
+        assert (info_path / "licenses" / "LICENSE").read_text() == "MIT License content"
+
+    def test_copies_multiple_license_files(self, tmp_path: Path):
+        """Multiple license files are all copied."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n"
+            "License-File: LICENSE\nLicense-File: NOTICE\n"
+        )
+        licenses_dir = dist_info / "licenses"
+        licenses_dir.mkdir()
+        (licenses_dir / "LICENSE").write_text("MIT")
+        (licenses_dir / "NOTICE").write_text("Notice text")
+
+        info_path = tmp_path / "info"
+        info_path.mkdir()
+
+        copied = copy_licenses_to_info(dist_info, info_path)
+
+        assert set(copied) == {"LICENSE", "NOTICE"}
+        assert (info_path / "licenses" / "LICENSE").exists()
+        assert (info_path / "licenses" / "NOTICE").exists()
+
+    def test_returns_empty_when_no_licenses(self, tmp_path: Path):
+        """Returns empty list when no license files exist."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n")
+
+        info_path = tmp_path / "info"
+        info_path.mkdir()
+
+        copied = copy_licenses_to_info(dist_info, info_path)
+
+        assert copied == []
+        assert not (info_path / "licenses").exists()
+
+    def test_creates_licenses_dir_if_missing(self, tmp_path: Path):
+        """Creates info/licenses/ directory if it doesn't exist."""
+        dist_info = tmp_path / "pkg-1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n")
+        (dist_info / "LICENSE").write_text("License text")
+
+        info_path = tmp_path / "info"
+        info_path.mkdir()
+
+        copy_licenses_to_info(dist_info, info_path)
+
+        assert (info_path / "licenses").is_dir()


### PR DESCRIPTION
Conda packages built from wheels now include license files in the
canonical info/licenses/ location. License files are discovered via
PEP 639 License-File metadata entries, with fallback to common patterns.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

# Description:                                                                                                                                                                                                        
                                                                                                                                                                                                                      
  What                                                                                                                                                                                                                
                                                                  
  - Copy license files from wheel's dist-info to conda info/licenses/ directory                                                                                                                                       
  - Discover licenses via PEP 639 License-File metadata entries   
  - Fallback to common license file patterns (LICENSE, COPYING, NOTICE, etc.) when no metadata                                                                                                                        
                                                                                                                                                                                                                      
  Why                                                                                                                                                                                                                 
                                                                                                                                                                                                                      
  Per CEP 34, info/licenses/ is the canonical location for license files in conda packages. This ensures conda-pypi generated packages are compliant and work correctly with conda tooling that expects licenses in   
  this location.
                                                                                                                                                                                                                      
  How                                                             

  - get_license_files() reads License-File entries from METADATA, checks dist-info/licenses/ (PEP 639), and falls back to pattern matching                                                                            
  - copy_licenses_to_info() copies found files to info/licenses/
  - Integration called automatically in build_conda()                                                                                                                                                                 
                                                                                                                                                                                                                      
  Testing                                                                                                                                                                                                             
                                                                                                                                                                                                                      
  10 new unit tests covering:                                                                                                                                                                                         
  - PEP 639 license discovery
  - Older wheel layouts                                                                                                                                                                                               
  - Fallback patterns                                             
  - Edge cases (no licenses, missing files)                                                                                                                                                                           
                                                                                                                                                                                                                      
  All 66 unit tests pass.                                                                                                                                                                                             
                                                                                                                                                                                                                      
  AI Disclosure                                                                                                                                                                                                       
                                                                                                                                                                                                                      
  AI used: Implementation following human-approved design from Slack discussion. PR description generation.                                                                                                           
  Human involvement: Provided requirements and design direction

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
