### PR TITLE
Fix license metadata

### DIFF
--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -134,7 +134,7 @@ class CondaMetadata:
             "summary": metadata.get("summary") or "",
             "description": metadata.get("description") or "",
             # https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression
-            "license": metadata.get("license_expression") or metadata.get("license") or "",
+            "license": metadata.get("License-Expression") or metadata.get("License") or "",
         }
 
         if project_urls := metadata.get_all("project-url"):

--- a/news/fix-license-metadata.md
+++ b/news/fix-license-metadata.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Fix license metadata extraction from wheel METADATA files. The code was using underscore keys (`license_expression`, `license`) but `email.message.Message` requires hyphen keys matching the actual METADATA headers (`License-Expression`, `License`).

--- a/tests/test_license_files.py
+++ b/tests/test_license_files.py
@@ -1,7 +1,10 @@
 from importlib.metadata import PathDistribution
 from pathlib import Path
 
+import pytest
+
 from conda_pypi.license_files import copy_into_info_licenses, package_metadata_from_metadata_body
+from conda_pypi.translate import CondaMetadata
 
 
 def test_package_metadata_from_body_matches_path_distribution(tmp_path: Path):
@@ -105,3 +108,21 @@ def test_license_file_multi_segment_under_licenses_subdir(tmp_path: Path):
 
     assert rel_paths == ["info/licenses/licenses/docs/NOTICE"]
     assert (info_dir / "licenses" / "licenses" / "docs" / "NOTICE").read_text() == "Legal\n"
+
+
+@pytest.mark.parametrize(
+    "license_header,expected",
+    [
+        pytest.param("License-Expression: MIT", "MIT", id="license-expression"),
+        pytest.param("License: MIT License", "MIT License", id="legacy-license"),
+    ],
+)
+def test_license_extracted_from_metadata(tmp_path: Path, license_header: str, expected: str):
+    """License metadata (License-Expression or legacy License) is extracted to about dict."""
+    dist_info_dir = tmp_path / "pkg-1.0.dist-info"
+    dist_info_dir.mkdir()
+    body = f"Metadata-Version: 2.4\nName: pkg\nVersion: 1.0\n{license_header}\n\n"
+    (dist_info_dir / "METADATA").write_text(body, encoding="utf-8")
+
+    conda_meta = CondaMetadata.from_distribution(PathDistribution(dist_info_dir))
+    assert conda_meta.about["license"] == expected


### PR DESCRIPTION

### Description

## What                                               
  - Fix metadata key names from `license_expression`/`license` to `License-Expression`/`License`                                                                                                                      
  - Add parametrized test covering both License-Expression (PEP 639) and legacy License fields  
                                                                                                                                                                                                                      
  ## Why                                                                                                                                                                                                              
  Wheels with valid license metadata (e.g., `License-Expression: MIT`) were producing .conda packages with empty license fields in `about.json`. The `email.message.Message` class backing wheel metadata is          
  case-insensitive but hyphen-sensitive - underscores don't match hyphens.                                                                                                                                            
                                                                                                                                                                                                                      
  ## How
  Single-line fix in `translate.py:137`. The existing pattern in `license_files.py` already correctly uses `"License-File"` with hyphens.                                                                             
                                                                                                                                         
  ## Testing                                                                                                                                                                                                          
  - Added parametrized test for both License-Expression and legacy License extraction
  - All 7 license tests pass                                                                                                                                                                                          
                                                                                                                                                                                                                      
  ## AI Disclosure                                                                                                                                                                                                    
  **AI used:** Investigation, implementation, test writing, PR description                                                                                                                                            
  **Human involvement:** Identified the bug (Dan Yeaw), approved design and commits, reviewed code                                                                                                                    
                                                                                                                                                                                                                     

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
