### PR TITLE
Fix archive structure

### DIFF
--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -186,7 +186,17 @@ def build_conda(
     (build_path / "info" / "paths.json").write_text(json_dumps(paths))
 
     with conda_builder(file_id, output_path) as tar:
-        tar.add(build_path, "", filter=filter)
+        for child in sorted(build_path.iterdir()):
+            if child.name == "info":
+                # Add info directory contents with "info/" prefix to route to
+                # info_tar (CondaTarFile.is_info uses name.startswith("info/")).
+                # Skip the directory entry itself to avoid it going to pkg_tar.
+                for info_entry in child.rglob("*"):
+                    if info_entry.is_file():
+                        arcname = str(info_entry.relative_to(build_path))
+                        tar.add(info_entry, arcname, filter=filter)
+            else:
+                tar.add(child, child.name, recursive=True, filter=filter)
 
     return output_path / f"{file_id}.conda"
 

--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -192,9 +192,24 @@ def build_conda(
                 # info_tar (CondaTarFile.is_info uses name.startswith("info/")).
                 # Skip the directory entry itself to avoid it going to pkg_tar.
                 for info_entry in child.rglob("*"):
-                    if info_entry.is_file():
-                        arcname = str(info_entry.relative_to(build_path))
+                    arcname = str(info_entry.relative_to(build_path))
+                    if on_win:
+                        arcname = win_path_to_unix(arcname)
+                    if info_entry.is_symlink():
+                        # Validate symlink target stays within build_path (untrusted wheel input)
+                        try:
+                            target = info_entry.resolve()
+                            if not target.is_relative_to(build_path):
+                                log.warning(f"Skipping symlink with external target: {info_entry}")
+                                continue
+                        except (OSError, ValueError):
+                            log.warning(f"Skipping unresolvable symlink: {info_entry}")
+                            continue
                         tar.add(info_entry, arcname, filter=filter)
+                    elif info_entry.is_file():
+                        tar.add(info_entry, arcname, filter=filter)
+                    elif info_entry.is_dir():
+                        tar.add(info_entry, arcname, recursive=False, filter=filter)
             else:
                 tar.add(child, child.name, recursive=True, filter=filter)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -123,3 +123,78 @@ def test_extract_whl_copies_licenses_to_info_licenses(
     lic = dest / "info" / "licenses" / "LICENSE"
     assert lic.is_file()
     assert lic.read_bytes() == b"BSD-3-Clause placeholder license text\n"
+
+
+def test_conda_package_conforms_to_cep_34_35(
+    tmp_env: TmpEnvFixture,
+    pypi_demo_package_wheel_path: Path,
+    tmp_path: Path,
+):
+    """Validate package conforms to CEP 34 (contents) and CEP 35 (file format).
+
+    CEP 35 MUST requirements tested:
+    - info-* tarball MUST contain the full info/ folder
+    - pkg-* tarball MUST carry everything else
+    - Root level of tarballs MUST match target location (no intermediate subdirectories)
+
+    CEP 34 MUST requirements tested:
+    - Package MUST include info/index.json and info/paths.json
+    - info/paths.json MUST NOT list contents of info/ folder
+    - conda-meta/ MUST NOT be present
+    - info/repodata_record.json MUST NOT be present
+    """
+    target_package_path, paths_json = _build_demo_conda_and_paths(
+        tmp_env, pypi_demo_package_wheel_path, tmp_path
+    )
+
+    # Collect all entries from both archives
+    info_entries = [m.name for _, m in package_streaming.stream_conda_info(target_package_path)]
+    pkg_entries = [
+        m.name for _, m in package_streaming.stream_conda_component(target_package_path)
+    ]
+
+    # === CEP 35: Archive structure requirements ===
+
+    # "info-* tarball MUST contain the full info/ folder"
+    # All info archive entries must start with 'info/'
+    invalid_info = [e for e in info_entries if not e.startswith("info/") and e != "info"]
+    assert not invalid_info, (
+        f"CEP 35 violation: info archive has entries not under info/: {invalid_info}"
+    )
+
+    # "pkg-* tarball MUST carry everything else"
+    # No pkg entries should be info/ content
+    misplaced_info = [
+        e for e in pkg_entries if e.startswith("info/") or e == "info" or e == "info/"
+    ]
+    assert not misplaced_info, f"CEP 35 violation: pkg archive has info/ entries: {misplaced_info}"
+
+    # "Root level MUST match target location (no intermediate subdirectories)"
+    # No absolute paths (leading /) or empty strings representing root
+    all_entries = info_entries + pkg_entries
+    invalid_roots = [e for e in all_entries if e.startswith("/") or e == "" or e == "/"]
+    assert not invalid_roots, (
+        f"CEP 35 violation: archive has intermediate subdirectories or absolute paths: {invalid_roots}"
+    )
+
+    # === CEP 34: Package contents requirements ===
+
+    # "Package MUST include info/index.json and info/paths.json"
+    assert "info/index.json" in info_entries, "CEP 34 violation: info/index.json missing"
+    assert "info/paths.json" in info_entries, "CEP 34 violation: info/paths.json missing"
+
+    # "info/paths.json MUST NOT list contents of info/ folder"
+    paths_in_paths_json = [p["_path"] for p in paths_json.get("paths", [])]
+    info_in_paths = [p for p in paths_in_paths_json if p.startswith("info/") or p == "info"]
+    assert not info_in_paths, (
+        f"CEP 34 violation: info/paths.json lists info/ contents: {info_in_paths}"
+    )
+
+    # "conda-meta/ directory MUST NOT be populated by conda packages"
+    conda_meta = [e for e in all_entries if e.startswith("conda-meta/") or e == "conda-meta"]
+    assert not conda_meta, f"CEP 34 violation: package contains conda-meta/: {conda_meta}"
+
+    # "info/repodata_record.json MUST NOT be present in distributed artifacts"
+    assert "info/repodata_record.json" not in info_entries, (
+        "CEP 34 violation: info/repodata_record.json must not be in distributed artifacts"
+    )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -157,7 +157,7 @@ def test_conda_package_conforms_to_cep_34_35(
 
     # "info-* tarball MUST contain the full info/ folder"
     # All info archive entries must start with 'info/'
-    invalid_info = [e for e in info_entries if not e.startswith("info/") and e != "info"]
+    invalid_info = [e for e in info_entries if not e.startswith("info")]
     assert not invalid_info, (
         f"CEP 35 violation: info archive has entries not under info/: {invalid_info}"
     )
@@ -172,7 +172,7 @@ def test_conda_package_conforms_to_cep_34_35(
     # "Root level MUST match target location (no intermediate subdirectories)"
     # No absolute paths (leading /) or empty strings representing root
     all_entries = info_entries + pkg_entries
-    invalid_roots = [e for e in all_entries if e.startswith("/") or e == "" or e == "/"]
+    invalid_roots = [e for e in all_entries if e.startswith("/") or e == ""]
     assert not invalid_roots, (
         f"CEP 35 violation: archive has intermediate subdirectories or absolute paths: {invalid_roots}"
     )

--- a/tests/test_conda_create.py
+++ b/tests/test_conda_create.py
@@ -37,7 +37,15 @@ def test_indexable(tmp_path):
     (dest / "info" / "paths.json").write_text(json.dumps(paths))
 
     with conda_builder(record.stem, noarch) as tar:
-        tar.add(dest, "", filter=filter)
+        for child in sorted(dest.iterdir()):
+            if child.name == "info":
+                # Add info contents with "info/" prefix to route to info_tar.
+                for info_entry in child.rglob("*"):
+                    if info_entry.is_file():
+                        arcname = str(info_entry.relative_to(dest))
+                        tar.add(info_entry, arcname, filter=filter)
+            else:
+                tar.add(child, child.name, recursive=True, filter=filter)
 
     update_index(tmp_path)
 

--- a/tests/test_conda_create.py
+++ b/tests/test_conda_create.py
@@ -1,9 +1,12 @@
 import hashlib
 import json
+import logging
 import os
 from pathlib import Path
 
 from conda.cli.main import main_subshell
+from conda.common.compat import on_win
+from conda.common.path.windows import win_path_to_unix
 from conda.exceptions import DryRunExit
 from conda_package_streaming.create import conda_builder
 
@@ -12,6 +15,7 @@ from conda_pypi.conda_build_utils import PathType, sha256_checksum
 from conda_pypi.index import update_index
 from conda_pypi.translate import PackageRecord
 
+log = logging.getLogger(__name__)
 here = Path(__file__).parent
 
 
@@ -41,9 +45,24 @@ def test_indexable(tmp_path):
             if child.name == "info":
                 # Add info contents with "info/" prefix to route to info_tar.
                 for info_entry in child.rglob("*"):
-                    if info_entry.is_file():
-                        arcname = str(info_entry.relative_to(dest))
+                    arcname = str(info_entry.relative_to(dest))
+                    if on_win:
+                        arcname = win_path_to_unix(arcname)
+                    if info_entry.is_symlink():
+                        # Validate symlink target stays within dest
+                        try:
+                            target = info_entry.resolve()
+                            if not target.is_relative_to(dest):
+                                log.warning(f"Skipping symlink with external target: {info_entry}")
+                                continue
+                        except (OSError, ValueError):
+                            log.warning(f"Skipping unresolvable symlink: {info_entry}")
+                            continue
                         tar.add(info_entry, arcname, filter=filter)
+                    elif info_entry.is_file():
+                        tar.add(info_entry, arcname, filter=filter)
+                    elif info_entry.is_dir():
+                        tar.add(info_entry, arcname, recursive=False, filter=filter)
             else:
                 tar.add(child, child.name, recursive=True, filter=filter)
 


### PR DESCRIPTION

### Description

NB this PR still needs manual checking and refinement.

## What                                                         
  - Fix CEP 35 violations: spurious `/` root entry and `info` directory misrouted to pkg archive                                                                                                                      
  - Handle symlinks and directories in info/ per CEP 34 path_type spec                                                                                                                                                
  - Add symlink target validation to prevent archive slip from untrusted wheels                                                                                                                                       
  - Add comprehensive CEP 34/35 compliance test                                                                                                                                                                       
                                                                                                                                                                                                                      
  ## Why                                                                                                                                                                                                              
  Generated `.conda` packages violated CEP 35 ("root level MUST match target location"), causing tar warnings and potentially triggering security scanners.                                                           
                                                                                                                                                                                                                      
  ## How                                                                                                                                                                                                              
  Replace `tar.add(build_path, "")` with iteration over children, handling info/ specially to route entries correctly to info_tar via CondaTarFile's `name.startswith("info/")` check. Symlinks are validated to
  ensure targets stay within build_path.                                                                                                                                                                              
                                                                                                                                                                                                                      
  ## Testing
  - New `test_conda_package_conforms_to_cep_34_35` validates all MUST requirements                                                                                                                                    
  - All existing tests pass                                                                                                                                                                                           
  - Linting clean                                                                                                                                                                                                     
                                                                                                                                                                                                                      
  ## AI Disclosure                                                                                                                                                                                                    
  **AI used:** Implementation, test writing, PR description                                                                                                                                                           
  **Human involvement:** Designed approach, reviewed all changes, approved architecture decisions, identified security concern (untrusted wheel symlinks) 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
