### PR TITLE
Implement pip external installer plugin (resolve with resolvelib + unearth, install with conda)

### DIFF
--- a/.github/workflows/review-build.yml
+++ b/.github/workflows/review-build.yml
@@ -1,0 +1,116 @@
+name: Review Builds
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  remove-build-label:
+    if: >-
+      !github.event.repository.fork
+      && github.event.label.name == 'build::review'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove build label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            })
+            const buildLabel = 'build::review'
+            const labels = pullRequest.labels.map(label => label.name)
+            if (labels.includes(buildLabel)) {
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: context.issue.number,
+                name: buildLabel,
+              })
+            }
+
+  build:
+    if: >-
+      !github.event.repository.fork
+      && github.event.label.name == 'build::review'
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            subdir: linux-64
+          - runs-on: macos-latest
+            subdir: osx-arm64
+          - runs-on: windows-latest
+            subdir: win-64
+    defaults:
+      run:
+        shell: bash --noprofile --norc -euo pipefail {0}
+    env:
+      PIXI_ENV_NAME: build-py312
+      PYTHONUNBUFFERED: "1"
+      CONDA_BLD_PATH: ${{ github.workspace }}/pkgs
+      PACKAGE_NAME: conda-pypi
+      ANACONDA_ORG_CHANNEL: conda-canary
+      ANACONDA_ORG_LABEL: ${{ github.repository }}/pr/${{ github.event.number }}
+      BINSTAR_API_TOKEN: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
+        with:
+          environments: ${{ env.PIXI_ENV_NAME }}
+      - name: Fix Ubuntu configuration
+        if: startswith(matrix.runs-on, 'ubuntu-')
+        run:
+          sudo rm -f /etc/pip.conf
+      - name: Setup project for building
+        run: |
+          pixi run --environment ${{ env.PIXI_ENV_NAME }} dev
+          pixi run --environment ${{ env.PIXI_ENV_NAME }} conda config --add channels defaults
+          pixi run --environment ${{ env.PIXI_ENV_NAME }} conda config --add channels conda-forge
+      - name: Build recipe
+        env:
+          _CONDA_BUILD_ISOLATED_ACTIVATION: "1"
+        run: pixi run --environment ${{ env.PIXI_ENV_NAME }} build
+      - name: Upload to conda-canary
+        shell: bash
+        run: |
+          SEARCH_ROOT="$CONDA_BLD_PATH/${{ matrix.subdir }}"
+          if [[ ! -d "$SEARCH_ROOT" ]]; then
+            echo "Expected build output directory $SEARCH_ROOT not found" >&2
+            exit 1
+          fi
+
+          PACKAGES=(
+            $(
+              find "$SEARCH_ROOT" -type f \
+              \( -name "${PACKAGE_NAME}-*.conda" -o -name "${PACKAGE_NAME}-*.tar.bz2" \) \
+              -print | sort
+            )
+          )
+
+          if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+            echo "No conda packages found in $SEARCH_ROOT" >&2
+            exit 1
+          fi
+
+          printf 'Uploading packages to %s/label/%s:\n' "$ANACONDA_ORG_CHANNEL" "$ANACONDA_ORG_LABEL"
+          printf '  %s\n' "${PACKAGES[@]}"
+          pixi run --environment ${{ env.PIXI_ENV_NAME }} \
+            anaconda \
+            upload \
+            --force \
+            --register \
+            --no-progress \
+            --user "$ANACONDA_ORG_CHANNEL" \
+            --label "$ANACONDA_ORG_LABEL" \
+            "${PACKAGES[@]}"

--- a/conda_pypi/env_installer.py
+++ b/conda_pypi/env_installer.py
@@ -1,10 +1,9 @@
 """
 Environment installer plugin for handling pip: section packages.
 
-Uses pip as a resolver only (--dry-run --report) to determine wheel URLs,
-then passes those URLs to conda install where the registered .whl package
-extractor handles the actual installation. This avoids calling pip install
-directly and sidesteps EXTERNALLY-MANAGED (PEP 668) entirely.
+Resolves PyPI dependencies using resolvelib + unearth, then installs the
+resolved wheels via ``conda install`` (using the registered .whl package
+extractor).  No pip subprocess is involved at any point.
 """
 
 from __future__ import annotations
@@ -14,36 +13,28 @@ from logging import getLogger
 from conda.base.context import context
 from conda.reporters import get_spinner
 
-from conda_pypi.main import dry_run_pip_json, run_conda_cli
+from conda_pypi.main import run_conda_cli
+from conda_pypi.resolver import make_finder, resolve
 
 log = getLogger(f"conda.{__name__}")
 
 
 def install(prefix, specs, args, *_, workdir=None, **kwargs):
     """
-    Install pip-section packages using pip as resolver + conda as installer.
-
-    Uses pip's --dry-run --report to resolve packages and obtain wheel URLs,
-    then installs those wheels via conda (which uses the .whl package extractor
-    registered by conda-pypi). No pip install subprocess is ever executed
-    against the target environment.
+    Install pip-section packages via resolvelib + conda wheel extractor.
     """
     if not specs:
         return None
 
-    with get_spinner("Resolving PyPI dependencies"):
-        report = dry_run_pip_json(list(specs))
+    finder = make_finder(prefix)
 
-    installs = report.get("install", [])
+    with get_spinner("Resolving PyPI dependencies"):
+        installs = resolve(list(specs), finder)
+
     if not installs:
         return None
 
-    wheel_urls = []
-    for item in installs:
-        url = item.get("download_info", {}).get("url")
-        if url:
-            wheel_urls.append(url)
-
+    wheel_urls = [item["url"] for item in installs if item["url"]]
     if not wheel_urls:
         return None
 
@@ -62,4 +53,4 @@ def install(prefix, specs, args, *_, workdir=None, **kwargs):
     if rc != 0:
         return None
 
-    return [item["metadata"]["name"] for item in installs if "metadata" in item]
+    return [item["name"] for item in installs if item["name"]]

--- a/conda_pypi/env_installer.py
+++ b/conda_pypi/env_installer.py
@@ -1,0 +1,65 @@
+"""
+Environment installer plugin for handling pip: section packages.
+
+Uses pip as a resolver only (--dry-run --report) to determine wheel URLs,
+then passes those URLs to conda install where the registered .whl package
+extractor handles the actual installation. This avoids calling pip install
+directly and sidesteps EXTERNALLY-MANAGED (PEP 668) entirely.
+"""
+
+from __future__ import annotations
+
+from logging import getLogger
+
+from conda.base.context import context
+from conda.reporters import get_spinner
+
+from conda_pypi.main import dry_run_pip_json, run_conda_cli
+
+log = getLogger(f"conda.{__name__}")
+
+
+def install(prefix, specs, args, *_, workdir=None, **kwargs):
+    """
+    Install pip-section packages using pip as resolver + conda as installer.
+
+    Uses pip's --dry-run --report to resolve packages and obtain wheel URLs,
+    then installs those wheels via conda (which uses the .whl package extractor
+    registered by conda-pypi). No pip install subprocess is ever executed
+    against the target environment.
+    """
+    if not specs:
+        return None
+
+    with get_spinner("Resolving PyPI dependencies"):
+        report = dry_run_pip_json(list(specs))
+
+    installs = report.get("install", [])
+    if not installs:
+        return None
+
+    wheel_urls = []
+    for item in installs:
+        url = item.get("download_info", {}).get("url")
+        if url:
+            wheel_urls.append(url)
+
+    if not wheel_urls:
+        return None
+
+    if not context.quiet and not context.json:
+        log.info("Installing %d PyPI packages via conda wheel extractor", len(wheel_urls))
+
+    rc = run_conda_cli(
+        "install",
+        "--prefix",
+        str(prefix),
+        "--yes",
+        "--quiet",
+        *wheel_urls,
+    )
+
+    if rc != 0:
+        return None
+
+    return [item["metadata"]["name"] for item in installs if "metadata" in item]

--- a/conda_pypi/plugin.py
+++ b/conda_pypi/plugin.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from conda.plugins import hookimpl
 from conda.plugins.types import (
-    CondaExternalInstaller,
     CondaPackageExtractor,
     CondaPostCommand,
     CondaSubcommand,
@@ -11,6 +10,11 @@ from conda.plugins.types import (
 from conda_pypi import cli, post_command
 from conda_pypi.main import ensure_target_env_has_externally_managed
 from conda_pypi.package_extractors.whl import extract_whl_as_conda_pkg
+
+try:
+    from conda.plugins.types import CondaExternalInstaller
+except ImportError:
+    CondaExternalInstaller = None
 
 
 @hookimpl
@@ -46,12 +50,14 @@ def conda_package_extractors():
     )
 
 
-@hookimpl
-def conda_external_installers():
-    from conda_pypi.env_installer import install
+if CondaExternalInstaller is not None:
 
-    yield CondaExternalInstaller(
-        name="pypi",
-        install=install,
-        aliases=("pip",),
-    )
+    @hookimpl
+    def conda_external_installers():
+        from conda_pypi.env_installer import install
+
+        yield CondaExternalInstaller(
+            name="pypi",
+            install=install,
+            aliases=("pip",),
+        )

--- a/conda_pypi/plugin.py
+++ b/conda_pypi/plugin.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from conda.plugins import hookimpl
-from conda.plugins.types import CondaPackageExtractor, CondaPostCommand, CondaSubcommand
+from conda.plugins.types import (
+    CondaExternalInstaller,
+    CondaPackageExtractor,
+    CondaPostCommand,
+    CondaSubcommand,
+)
 
 from conda_pypi import cli, post_command
 from conda_pypi.main import ensure_target_env_has_externally_managed
@@ -38,4 +43,15 @@ def conda_package_extractors():
         name="wheel-package",
         extensions=[".whl"],
         extract=extract_whl_as_conda_pkg,
+    )
+
+
+@hookimpl
+def conda_external_installers():
+    from conda_pypi.env_installer import install
+
+    yield CondaExternalInstaller(
+        name="pypi",
+        install=install,
+        aliases=("pip",),
     )

--- a/conda_pypi/resolver.py
+++ b/conda_pypi/resolver.py
@@ -21,7 +21,6 @@ from packaging.version import Version
 from resolvelib import BaseReporter, Resolver
 from resolvelib.providers import AbstractProvider
 from unearth import PackageFinder
-from unearth.evaluator import Package
 
 from conda_pypi.downloader import DEFAULT_INDEX_URLS, get_package_finder
 
@@ -54,26 +53,25 @@ class Candidate:
 
 
 def _fetch_requires_dist(link) -> list[Requirement]:
-    """Extract Requires-Dist from PEP 658 metadata or wheel METADATA."""
-    raw = _fetch_metadata_bytes(link)
+    """Fetch PEP 658 metadata or fall back to extracting METADATA from the wheel."""
+    if link.dist_info_metadata:
+        resp = _requests.get(link.url_without_fragment + ".metadata", timeout=30)
+        resp.raise_for_status()
+        raw = resp.content
+    else:
+        resp = _requests.get(link.url_without_fragment, timeout=120, stream=True)
+        resp.raise_for_status()
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            for entry in zf.namelist():
+                if entry.endswith(".dist-info/METADATA"):
+                    raw = zf.read(entry)
+                    break
+            else:
+                raise RuntimeError(
+                    f"No METADATA found in wheel at {link.url_without_fragment}"
+                )
     msg = BytesParser().parsebytes(raw)
     return [Requirement(r) for r in (msg.get_all("Requires-Dist") or [])]
-
-
-def _fetch_metadata_bytes(link) -> bytes:
-    if link.dist_info_metadata:
-        url = link.url_without_fragment + ".metadata"
-        resp = _requests.get(url, timeout=30)
-        resp.raise_for_status()
-        return resp.content
-
-    resp = _requests.get(link.url_without_fragment, timeout=120, stream=True)
-    resp.raise_for_status()
-    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
-        for entry in zf.namelist():
-            if entry.endswith(".dist-info/METADATA"):
-                return zf.read(entry)
-    raise RuntimeError(f"No METADATA found in wheel at {link.url_without_fragment}")
 
 
 class PyPIProvider(AbstractProvider):
@@ -81,7 +79,7 @@ class PyPIProvider(AbstractProvider):
 
     def __init__(self, finder: PackageFinder) -> None:
         self._finder = finder
-        self._packages_cache: dict[str, list[Package]] = {}
+        self._packages_cache: dict[str, list] = {}
         self._extras: dict[str, set[str]] = {}
 
     def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
@@ -139,8 +137,8 @@ class PyPIProvider(AbstractProvider):
         return deps
 
 
-def get_index_urls() -> list[str]:
-    """Collect PyPI index URLs from environment (PIP_INDEX_URL, etc.)."""
+def make_finder(prefix: str | Path) -> PackageFinder:
+    """Build a ``PackageFinder`` for *prefix*'s Python, respecting env vars."""
     urls: list[str] = []
     index_url = os.environ.get("PIP_INDEX_URL")
     if index_url:
@@ -149,12 +147,7 @@ def get_index_urls() -> list[str]:
         urls.extend(DEFAULT_INDEX_URLS)
     extra = os.environ.get("PIP_EXTRA_INDEX_URL", "")
     urls.extend(u for u in extra.split() if u)
-    return urls
-
-
-def make_finder(prefix: str | Path) -> PackageFinder:
-    """Build a ``PackageFinder`` for *prefix*'s Python, respecting env vars."""
-    return get_package_finder(prefix, index_urls=get_index_urls())
+    return get_package_finder(prefix, index_urls=urls)
 
 
 def resolve(specs: list[str], finder: PackageFinder) -> list[dict[str, str]]:

--- a/conda_pypi/resolver.py
+++ b/conda_pypi/resolver.py
@@ -13,7 +13,6 @@ import os
 import zipfile
 from email.parser import BytesParser
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import requests as _requests
 from packaging.requirements import InvalidRequirement, Requirement
@@ -21,22 +20,12 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 from resolvelib import BaseReporter, Resolver
 from resolvelib.providers import AbstractProvider
-from unearth import PackageFinder, TargetPython
+from unearth import PackageFinder
+from unearth.evaluator import Package
 
-from conda_pypi.downloader import DEFAULT_INDEX_URLS
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
-    from typing import Any
-
-    from resolvelib.structs import RequirementInformation
+from conda_pypi.downloader import DEFAULT_INDEX_URLS, get_package_finder
 
 log = logging.getLogger(f"conda.{__name__}")
-
-
-# ---------------------------------------------------------------------------
-# Candidate — a concrete (name, version, link) triple
-# ---------------------------------------------------------------------------
 
 
 class Candidate:
@@ -44,7 +33,7 @@ class Candidate:
 
     __slots__ = ("name", "version", "link", "_deps")
 
-    def __init__(self, name: str, version: Version, link: Any) -> None:
+    def __init__(self, name: str, version: Version, link) -> None:
         self.name = name
         self.version = version
         self.link = link
@@ -64,46 +53,36 @@ class Candidate:
         return f"Candidate({self.name}=={self.version})"
 
 
-def _fetch_requires_dist(link: Any) -> list[Requirement]:
+def _fetch_requires_dist(link) -> list[Requirement]:
     """Extract Requires-Dist from PEP 658 metadata or wheel METADATA."""
     raw = _fetch_metadata_bytes(link)
     msg = BytesParser().parsebytes(raw)
     return [Requirement(r) for r in (msg.get_all("Requires-Dist") or [])]
 
 
-def _fetch_metadata_bytes(link: Any) -> bytes:
-    # PEP 658: index serves metadata alongside the wheel
+def _fetch_metadata_bytes(link) -> bytes:
     if link.dist_info_metadata:
         url = link.url_without_fragment + ".metadata"
         resp = _requests.get(url, timeout=30)
         resp.raise_for_status()
         return resp.content
 
-    # Fallback: download the wheel and extract METADATA from the zip
     resp = _requests.get(link.url_without_fragment, timeout=120, stream=True)
     resp.raise_for_status()
-    data = resp.content
-    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
         for entry in zf.namelist():
             if entry.endswith(".dist-info/METADATA"):
                 return zf.read(entry)
     raise RuntimeError(f"No METADATA found in wheel at {link.url_without_fragment}")
 
 
-# ---------------------------------------------------------------------------
-# Provider — resolvelib adapter backed by unearth
-# ---------------------------------------------------------------------------
-
-
 class PyPIProvider(AbstractProvider):
-    """resolvelib ``AbstractProvider`` backed by a ``PackageFinder``."""
+    """resolvelib provider backed by an unearth ``PackageFinder``."""
 
     def __init__(self, finder: PackageFinder) -> None:
         self._finder = finder
-        self._packages_cache: dict[str, Sequence[Any]] = {}
+        self._packages_cache: dict[str, list[Package]] = {}
         self._extras: dict[str, set[str]] = {}
-
-    # -- resolvelib interface ------------------------------------------------
 
     def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
         if isinstance(requirement_or_candidate, Candidate):
@@ -113,15 +92,7 @@ class PyPIProvider(AbstractProvider):
             self._extras.setdefault(name, set()).update(requirement_or_candidate.extras)
         return name
 
-    def get_preference(
-        self,
-        identifier: str,
-        resolutions: Mapping,
-        candidates: Mapping,
-        information: Mapping,
-        backtrack_causes: Sequence,
-    ) -> tuple[int, str]:
-        # Prefer already-pinned, then direct requirements, then fewer candidates
+    def get_preference(self, identifier, resolutions, candidates, information, backtrack_causes):
         if identifier in resolutions:
             return (-2, identifier)
         is_direct = any(
@@ -129,18 +100,13 @@ class PyPIProvider(AbstractProvider):
         )
         return (-1 if is_direct else 0, identifier)
 
-    def find_matches(
-        self,
-        identifier: str,
-        requirements: Mapping,
-        incompatibilities: Mapping,
-    ):
+    def find_matches(self, identifier, requirements, incompatibilities):
         reqs = list(requirements[identifier])
         bad = {c.version for c in incompatibilities.get(identifier, ())}
 
         if identifier not in self._packages_cache:
-            self._packages_cache[identifier] = self._finder.find_all_packages(
-                str(identifier)
+            self._packages_cache[identifier] = list(
+                self._finder.find_all_packages(str(identifier))
             )
 
         for pkg in self._packages_cache[identifier]:
@@ -173,11 +139,6 @@ class PyPIProvider(AbstractProvider):
         return deps
 
 
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
 def get_index_urls() -> list[str]:
     """Collect PyPI index URLs from environment (PIP_INDEX_URL, etc.)."""
     urls: list[str] = []
@@ -193,28 +154,16 @@ def get_index_urls() -> list[str]:
 
 def make_finder(prefix: str | Path) -> PackageFinder:
     """Build a ``PackageFinder`` for *prefix*'s Python, respecting env vars."""
-    from conda.core.prefix_data import PrefixData
-
-    from conda_pypi.exceptions import CondaPypiError
-
-    pd = PrefixData(str(prefix))
-    py_records = list(pd.query("python"))
-    if not py_records:
-        raise CondaPypiError(f"Python not found in {prefix}")
-    py_ver = tuple(int(x) for x in py_records[0].version.split("."))
-    return PackageFinder(
-        index_urls=get_index_urls(),
-        target_python=TargetPython(py_ver=py_ver),
-        only_binary=":all:",
-    )
+    return get_package_finder(prefix, index_urls=get_index_urls())
 
 
 def resolve(specs: list[str], finder: PackageFinder) -> list[dict[str, str]]:
     """
-    Resolve PyPI requirement strings → list of ``{name, version, url}``.
+    Resolve PyPI requirement strings into a list of ``{name, version, url}``
+    dicts suitable for passing to ``conda install``.
 
-    URL/path specs (not parseable as PEP 508 requirements) are returned
-    as-is with *name* and *version* set to empty strings.
+    Specs that cannot be parsed as PEP 508 requirements (URLs, paths) are
+    returned as-is with empty *name* and *version*.
     """
     requirements: list[Requirement] = []
     passthrough_urls: list[str] = []

--- a/conda_pypi/resolver.py
+++ b/conda_pypi/resolver.py
@@ -1,0 +1,244 @@
+"""
+PyPI dependency resolver using resolvelib + unearth.
+
+Replaces the pip subprocess (--dry-run --report) with a pure-library
+approach for resolving PyPI dependencies and obtaining wheel URLs.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import zipfile
+from email.parser import BytesParser
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import requests as _requests
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+from resolvelib import BaseReporter, Resolver
+from resolvelib.providers import AbstractProvider
+from unearth import PackageFinder, TargetPython
+
+from conda_pypi.downloader import DEFAULT_INDEX_URLS
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any
+
+    from resolvelib.structs import RequirementInformation
+
+log = logging.getLogger(f"conda.{__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Candidate — a concrete (name, version, link) triple
+# ---------------------------------------------------------------------------
+
+
+class Candidate:
+    """A concrete package version backed by an unearth Package link."""
+
+    __slots__ = ("name", "version", "link", "_deps")
+
+    def __init__(self, name: str, version: Version, link: Any) -> None:
+        self.name = name
+        self.version = version
+        self.link = link
+        self._deps: list[Requirement] | None = None
+
+    @property
+    def url(self) -> str:
+        return self.link.url_without_fragment
+
+    @property
+    def dependencies(self) -> list[Requirement]:
+        if self._deps is None:
+            self._deps = _fetch_requires_dist(self.link)
+        return self._deps
+
+    def __repr__(self) -> str:
+        return f"Candidate({self.name}=={self.version})"
+
+
+def _fetch_requires_dist(link: Any) -> list[Requirement]:
+    """Extract Requires-Dist from PEP 658 metadata or wheel METADATA."""
+    raw = _fetch_metadata_bytes(link)
+    msg = BytesParser().parsebytes(raw)
+    return [Requirement(r) for r in (msg.get_all("Requires-Dist") or [])]
+
+
+def _fetch_metadata_bytes(link: Any) -> bytes:
+    # PEP 658: index serves metadata alongside the wheel
+    if link.dist_info_metadata:
+        url = link.url_without_fragment + ".metadata"
+        resp = _requests.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp.content
+
+    # Fallback: download the wheel and extract METADATA from the zip
+    resp = _requests.get(link.url_without_fragment, timeout=120, stream=True)
+    resp.raise_for_status()
+    data = resp.content
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for entry in zf.namelist():
+            if entry.endswith(".dist-info/METADATA"):
+                return zf.read(entry)
+    raise RuntimeError(f"No METADATA found in wheel at {link.url_without_fragment}")
+
+
+# ---------------------------------------------------------------------------
+# Provider — resolvelib adapter backed by unearth
+# ---------------------------------------------------------------------------
+
+
+class PyPIProvider(AbstractProvider):
+    """resolvelib ``AbstractProvider`` backed by a ``PackageFinder``."""
+
+    def __init__(self, finder: PackageFinder) -> None:
+        self._finder = finder
+        self._packages_cache: dict[str, Sequence[Any]] = {}
+        self._extras: dict[str, set[str]] = {}
+
+    # -- resolvelib interface ------------------------------------------------
+
+    def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
+        if isinstance(requirement_or_candidate, Candidate):
+            return requirement_or_candidate.name
+        name = canonicalize_name(requirement_or_candidate.name)
+        if requirement_or_candidate.extras:
+            self._extras.setdefault(name, set()).update(requirement_or_candidate.extras)
+        return name
+
+    def get_preference(
+        self,
+        identifier: str,
+        resolutions: Mapping,
+        candidates: Mapping,
+        information: Mapping,
+        backtrack_causes: Sequence,
+    ) -> tuple[int, str]:
+        # Prefer already-pinned, then direct requirements, then fewer candidates
+        if identifier in resolutions:
+            return (-2, identifier)
+        is_direct = any(
+            info.parent is None for info in information.get(identifier, ())
+        )
+        return (-1 if is_direct else 0, identifier)
+
+    def find_matches(
+        self,
+        identifier: str,
+        requirements: Mapping,
+        incompatibilities: Mapping,
+    ):
+        reqs = list(requirements[identifier])
+        bad = {c.version for c in incompatibilities.get(identifier, ())}
+
+        if identifier not in self._packages_cache:
+            self._packages_cache[identifier] = self._finder.find_all_packages(
+                str(identifier)
+            )
+
+        for pkg in self._packages_cache[identifier]:
+            if pkg.version is None:
+                continue
+            ver = Version(pkg.version)
+            if ver in bad:
+                continue
+            if all(ver in r.specifier for r in reqs):
+                yield Candidate(canonicalize_name(pkg.name), ver, pkg.link)
+
+    def is_satisfied_by(self, requirement: Requirement, candidate: Candidate) -> bool:
+        return (
+            canonicalize_name(requirement.name) == candidate.name
+            and candidate.version in requirement.specifier
+        )
+
+    def get_dependencies(self, candidate: Candidate) -> list[Requirement]:
+        extras = self._extras.get(candidate.name, set())
+        deps: list[Requirement] = []
+        for dep in candidate.dependencies:
+            if dep.marker is None:
+                deps.append(dep)
+            elif extras and any(
+                dep.marker.evaluate({"extra": e}) for e in extras
+            ):
+                deps.append(dep)
+            elif dep.marker.evaluate():
+                deps.append(dep)
+        return deps
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_index_urls() -> list[str]:
+    """Collect PyPI index URLs from environment (PIP_INDEX_URL, etc.)."""
+    urls: list[str] = []
+    index_url = os.environ.get("PIP_INDEX_URL")
+    if index_url:
+        urls.append(index_url)
+    else:
+        urls.extend(DEFAULT_INDEX_URLS)
+    extra = os.environ.get("PIP_EXTRA_INDEX_URL", "")
+    urls.extend(u for u in extra.split() if u)
+    return urls
+
+
+def make_finder(prefix: str | Path) -> PackageFinder:
+    """Build a ``PackageFinder`` for *prefix*'s Python, respecting env vars."""
+    from conda.core.prefix_data import PrefixData
+
+    from conda_pypi.exceptions import CondaPypiError
+
+    pd = PrefixData(str(prefix))
+    py_records = list(pd.query("python"))
+    if not py_records:
+        raise CondaPypiError(f"Python not found in {prefix}")
+    py_ver = tuple(int(x) for x in py_records[0].version.split("."))
+    return PackageFinder(
+        index_urls=get_index_urls(),
+        target_python=TargetPython(py_ver=py_ver),
+        only_binary=":all:",
+    )
+
+
+def resolve(specs: list[str], finder: PackageFinder) -> list[dict[str, str]]:
+    """
+    Resolve PyPI requirement strings → list of ``{name, version, url}``.
+
+    URL/path specs (not parseable as PEP 508 requirements) are returned
+    as-is with *name* and *version* set to empty strings.
+    """
+    requirements: list[Requirement] = []
+    passthrough_urls: list[str] = []
+
+    for spec in specs:
+        try:
+            requirements.append(Requirement(spec))
+        except InvalidRequirement:
+            passthrough_urls.append(spec)
+
+    result: list[dict[str, str]] = [
+        {"name": "", "version": "", "url": u} for u in passthrough_urls
+    ]
+
+    if requirements:
+        provider = PyPIProvider(finder)
+        resolved = Resolver(provider, BaseReporter()).resolve(requirements)
+        result.extend(
+            {
+                "name": str(c.name),
+                "version": str(c.version),
+                "url": c.url,
+            }
+            for c in resolved.mapping.values()
+        )
+
+    return result

--- a/pixi.lock
+++ b/pixi.lock
@@ -169,6 +169,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py310hd8f68c5_0.conda
@@ -369,6 +370,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ripgrep-15.1.0-h1ebd7d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rpds-py-0.30.0-py310haddc216_0.conda
@@ -562,6 +564,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-15.1.0-h748bcf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py310hf3301a5_0.conda
@@ -750,6 +753,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py310h034784e_0.conda
@@ -963,6 +967,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py311h902ca64_0.conda
@@ -1163,6 +1168,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ripgrep-15.1.0-h1ebd7d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rpds-py-0.30.0-py311hc91c717_0.conda
@@ -1356,6 +1362,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-15.1.0-h748bcf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py311h71babbd_0.conda
@@ -1544,6 +1551,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py311hf51aa87_0.conda
@@ -1757,6 +1765,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
@@ -1957,6 +1966,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ripgrep-15.1.0-h1ebd7d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rpds-py-0.30.0-py312h75d7d99_0.conda
@@ -2150,6 +2160,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-15.1.0-h748bcf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py312h6ef9ec0_0.conda
@@ -2338,6 +2349,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py312hdabe01f_0.conda
@@ -2550,6 +2562,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py313h843e2db_0.conda
@@ -2748,6 +2761,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ripgrep-15.1.0-h1ebd7d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rpds-py-0.30.0-py313h8f1d341_0.conda
@@ -2941,6 +2955,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-15.1.0-h748bcf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py313h2c089d5_0.conda
@@ -3129,6 +3144,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py313hfbe8231_0.conda
@@ -3340,6 +3356,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py314h2e6c369_0.conda
@@ -3538,6 +3555,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ripgrep-15.1.0-h1ebd7d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rpds-py-0.30.0-py314h02b7a91_0.conda
@@ -3731,6 +3749,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-15.1.0-h748bcf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py314haad56a0_0.conda
@@ -3919,6 +3938,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py314h9f07db2_0.conda
@@ -4062,6 +4082,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py314h0f05182_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -4173,6 +4194,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py314h2e8dab5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -4277,6 +4299,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py314ha14b1ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py314ha14b1ff_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -4375,6 +4398,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py314hc5dbbe4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py314hc5dbbe4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -4519,6 +4543,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py310h139afa4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py310h139afa4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -4670,6 +4695,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py310hef25091_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py310hef25091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -4812,6 +4838,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py310haea493c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py310haea493c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -4947,6 +4974,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py310h1637853_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py310h1637853_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -5102,6 +5130,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py312h5253ce2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -5227,6 +5256,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py312hd41f8a7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py312hd41f8a7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -5343,6 +5373,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py312hb3ab3e3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py312hb3ab3e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -5453,6 +5484,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py312he5662c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -5593,6 +5625,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rever-0.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py314h0f05182_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
@@ -5730,6 +5763,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rever-0.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py314h2e8dab5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
@@ -5860,6 +5894,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rever-0.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py314ha14b1ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py314ha14b1ff_1.conda
@@ -5972,6 +6007,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rever-0.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py314hc5dbbe4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py314hc5dbbe4_1.conda
@@ -6122,6 +6158,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py313h54dd161_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
@@ -6255,6 +6292,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py313h62ef0ea_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py313h62ef0ea_1.conda
@@ -6381,6 +6419,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py313h6688731_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
@@ -6500,6 +6539,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py313h5fd188c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
@@ -6650,6 +6690,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py310h139afa4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py310h139afa4_1.conda
@@ -6787,6 +6828,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py310hef25091_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py310hef25091_1.conda
@@ -6915,6 +6957,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py310haea493c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py310haea493c_1.conda
@@ -7036,6 +7079,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py310h1637853_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py310h1637853_1.conda
@@ -7187,6 +7231,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py311haee01d2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py311haee01d2_1.conda
@@ -7324,6 +7369,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py311h51cfe5d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py311h51cfe5d_1.conda
@@ -7452,6 +7498,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py311he363849_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py311he363849_1.conda
@@ -7573,6 +7620,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py311hf893f09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py311hf893f09_1.conda
@@ -7724,6 +7772,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py312h5253ce2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
@@ -7861,6 +7910,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py312hd41f8a7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py312hd41f8a7_1.conda
@@ -7989,6 +8039,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py312hb3ab3e3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py312hb3ab3e3_1.conda
@@ -8110,6 +8161,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py312he5662c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py312he5662c2_1.conda
@@ -8260,6 +8312,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py313h54dd161_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
@@ -8395,6 +8448,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py313h62ef0ea_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py313h62ef0ea_1.conda
@@ -8523,6 +8577,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py313h6688731_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
@@ -8644,6 +8699,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py313h5fd188c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
@@ -8793,6 +8849,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py314h0f05182_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
@@ -8928,6 +8985,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.18.17-py314h2e8dab5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
@@ -9056,6 +9114,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.17-py314ha14b1ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py314ha14b1ff_1.conda
@@ -9177,6 +9236,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.17-py314hc5dbbe4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py314hc5dbbe4_1.conda
@@ -11764,8 +11824,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-pypi
-  version: 0.8.1.dev7+g967efefe7
-  sha256: 0f65643b5acd66c52f330ce5d1d452342fe7a021213243d2f26e37f1b7a62e9e
+  version: 0.4.1.dev58+g7a8983313.d20260506
+  sha256: 11615d937900af1496f7b40391176641db87b362022b057ba741f605f5e7839d
   requires_dist:
   - build
   - conda-index>=0.11.0
@@ -11774,6 +11834,7 @@ packages:
   - packaging
   - pip
   - platformdirs
+  - resolvelib>=1.0
   - unearth
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/conda-rattler-solver-0.0.6-pyhcf101f3_0.conda
@@ -21127,6 +21188,16 @@ packages:
   - pkg:pypi/requests-toolbelt?source=hash-mapping
   size: 44285
   timestamp: 1733734886897
+- conda: https://conda.anaconda.org/conda-forge/noarch/resolvelib-1.2.1-pyhd8ed1ab_0.conda
+  sha256: 92027319cfb2ab3e38dc11594d7704d301d4048a1e2be531f55f7eafe744ffa5
+  md5: 1a8bcf0bb5d49ce0b1e9e31cceeb2b45
+  depends:
+  - python >=3.10
+  license: ISC
+  purls:
+  - pkg:pypi/resolvelib?source=hash-mapping
+  size: 335755
+  timestamp: 1760802465911
 - conda: https://conda.anaconda.org/conda-forge/noarch/rever-0.5.1-pyhd8ed1ab_1.conda
   sha256: b87d26be3989614971e8e12f0f2a00b81e5a17496df0982c10aa22edca8c2f93
   md5: 96a6ce51bc648ea7f293c1808e3b3633

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "packaging",
   "pip",
   "platformdirs",
+  "resolvelib>=1.0",
   "unearth",
 ]
 dynamic = ["version"]
@@ -58,6 +59,7 @@ conda-package-streaming = ">=0.11"
 conda-rattler-solver = ">=0.0.6"
 packaging = "*"
 pip = "*"
+resolvelib = ">=1.0"
 unearth = "*"
 
 [tool.pixi.pypi-dependencies]


### PR DESCRIPTION
### Description

Implements conda's new `conda_external_installers` plugin hook to handle the `pip:` section in `environment.yml` files.

- Resolves PyPI dependencies using **resolvelib + unearth** (no pip subprocess)
- Installs resolved wheels via `conda install` using the registered `.whl` package extractor
- No `pip install` is ever executed against the target environment
- Sidesteps `EXTERNALLY-MANAGED` (PEP 668) entirely

**Requires:** conda/conda#16035 (`conda_external_installers` plugin hook)

**Changes:**

- `conda_pypi/resolver.py` — resolvelib `Provider` backed by unearth `PackageFinder` for PyPI dependency resolution (PEP 658 metadata + wheel fallback)
- `conda_pypi/env_installer.py` — plugin install function: resolve → collect wheel URLs → `conda install`
- `conda_pypi/plugin.py` — register `CondaExternalInstaller(name="pypi", aliases=("pip",))`
- `pyproject.toml` — add `resolvelib>=1.0` dependency

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?