### PR TITLE
Disable EXTERNALLY-MANAGED file during beta, show notice instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Includes:
 - `conda pypi install -e .`: Converts a path to an editable `.conda` format package.
 - `conda pypi convert`: Convert PyPI packages to `.conda` format without installing them.
 - `conda install` from wheel channels (experimental): channels can serve pure Python wheels directly in `repodata.json`.
-- Adds `EXTERNALLY-MANAGED` to your environments.
+- A warning when running `conda create` or `conda install` with `pip` in the environment.
 
 ## Why?
 

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -189,6 +189,31 @@ def ensure_target_env_has_externally_managed(command: str):
         raise ValueError(f"command {command} not recognized.")
 
 
+def notify_externally_managed_future(command: str):
+    """
+    Beta-period post-command hook that prints a one-time notice about upcoming
+    EXTERNALLY-MANAGED enforcement instead of placing the marker file.
+    """
+    # Build environments are ephemeral; never show user-facing notices.
+    if os.environ.get("CONDA_BUILD_STATE") == "BUILD":
+        return
+    # Only notify in non-base environments where pip interop is relevant.
+    base_prefix = Path(context.conda_prefix)
+    target_prefix = Path(context.target_prefix)
+    if base_prefix == target_prefix or base_prefix.resolve() == target_prefix.resolve():
+        return
+    # No point warning about pip protection if pip isn't installed.
+    prefix_data = PrefixData(target_prefix)
+    if not list(prefix_data.query("pip")):
+        return
+    logger.warning(
+        "A future conda release will use PEP 668 to prevent 'pip install' "
+        "in conda environments. conda-pypi lets you install PyPI packages "
+        "natively with conda. "
+        "See: https://conda.github.io/conda-pypi/"
+    )
+
+
 def pypi_lines_for_explicit_lockfile(
     prefix: Path | str, checksums: Iterable[Literal["md5", "sha256"]] | None = None
 ) -> list[str]:

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -191,7 +191,7 @@ def ensure_target_env_has_externally_managed(command: str):
 
 def notify_externally_managed_future(command: str):
     """
-    Beta-period post-command hook that prints a one-time notice about upcoming
+    Beta-period post-command hook that logs a warning about upcoming
     EXTERNALLY-MANAGED enforcement instead of placing the marker file.
     """
     # Build environments are ephemeral; never show user-facing notices.
@@ -207,10 +207,14 @@ def notify_externally_managed_future(command: str):
     if not list(prefix_data.query("pip")):
         return
     logger.warning(
-        "A future conda release will use PEP 668 to prevent 'pip install' "
-        "in conda environments. conda-pypi lets you install PyPI packages "
-        "natively with conda. "
-        "See: https://conda.github.io/conda-pypi/"
+        "\n"
+        "  This environment has pip installed. A future conda release will\n"
+        "  protect conda environments from accidental 'pip install' usage.\n"
+        "  Try the beta to install PyPI packages natively with conda:\n"
+        "    conda config --set solver rattler\n"
+        "    conda config --append channels conda-pypi\n"
+        "    conda install <package>\n"
+        "  More info: https://docs.conda.io/projects/conda/en/stable/new-features.html"
     )
 
 

--- a/conda_pypi/plugin.py
+++ b/conda_pypi/plugin.py
@@ -4,7 +4,7 @@ from conda.plugins import hookimpl
 from conda.plugins.types import CondaPackageExtractor, CondaPostCommand, CondaSubcommand
 
 from conda_pypi import cli, post_command
-from conda_pypi.main import ensure_target_env_has_externally_managed
+from conda_pypi.main import notify_externally_managed_future
 from conda_pypi.package_extractors.whl import extract_whl_as_conda_pkg
 
 
@@ -21,9 +21,9 @@ def conda_subcommands():
 @hookimpl
 def conda_post_commands():
     yield CondaPostCommand(
-        name="conda-pypi-ensure-target-env-has-externally-managed",
-        action=ensure_target_env_has_externally_managed,
-        run_for={"install", "create", "update", "remove"},
+        name="conda-pypi-notify-externally-managed-future",
+        action=notify_externally_managed_future,
+        run_for={"install", "create"},
     )
     yield CondaPostCommand(
         name="conda-pypi-post-install-create",

--- a/conda_pypi/plugin.py
+++ b/conda_pypi/plugin.py
@@ -23,7 +23,7 @@ def conda_post_commands():
     yield CondaPostCommand(
         name="conda-pypi-notify-externally-managed-future",
         action=notify_externally_managed_future,
-        run_for={"install", "create"},
+        run_for={"install", "create", "env_create"},
     )
     yield CondaPostCommand(
         name="conda-pypi-post-install-create",

--- a/news/disable-externally-managed-beta
+++ b/news/disable-externally-managed-beta
@@ -1,0 +1,7 @@
+### Enhancements
+
+* Disable `EXTERNALLY-MANAGED` file placement during the community beta period. Instead, log an informational notice about upcoming pip protection when environments with pip are created or updated. (#350)
+
+### Deprecations
+
+* The `EXTERNALLY-MANAGED` file will be re-enabled in a future release once migration tooling is available. (#350)

--- a/news/disable-externally-managed-beta
+++ b/news/disable-externally-managed-beta
@@ -1,7 +1,7 @@
 ### Enhancements
 
-* Disable `EXTERNALLY-MANAGED` file placement during the community beta period. Instead, log an informational notice about upcoming pip protection when environments with pip are created or updated. (#350)
+* Disable `EXTERNALLY-MANAGED` file placement during the community beta period. Instead, log an informational notice about upcoming pip protection when environments with pip are created or updated. (#353 via #352)
 
 ### Deprecations
 
-* The `EXTERNALLY-MANAGED` file will be re-enabled in a future release once migration tooling is available. (#350)
+* The `EXTERNALLY-MANAGED` file will be re-enabled in a future release once migration tooling is available. (#353 via #352)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,6 +6,7 @@ from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
 from pytest_mock import MockerFixture
 
 from conda_pypi import plugin
+from conda_pypi.main import notify_externally_managed_future
 from conda_pypi.package_extractors import whl
 
 WHL_HTTP_URL = "https://files.pythonhosted.org/packages/45/7f/0e961cf3908bc4c1c3e027de2794f867c6c89fb4916fc7dba295a0e80a2d/boltons-25.0.0-py3-none-any.whl"
@@ -59,3 +60,73 @@ def test_extract_whl_as_conda_pkg(
 ):
     whl.extract_whl_as_conda_pkg(pypi_demo_package_wheel_path, tmp_path)
     assert (tmp_path / "info" / "index.json").is_file()
+
+
+@pytest.mark.parametrize("command", ["install", "create", "env_create"])
+def test_notify_warns_when_pip_installed(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    command: str,
+):
+    ctx = mocker.patch("conda_pypi.main.context")
+    ctx.conda_prefix = str(tmp_path / "base")
+    ctx.target_prefix = str(tmp_path / "env")
+    mocker.patch("conda_pypi.main.PrefixData").return_value.query.return_value = [
+        mocker.MagicMock()
+    ]
+    mock_logger = mocker.patch("conda_pypi.main.logger")
+
+    notify_externally_managed_future(command)
+
+    mock_logger.warning.assert_called_once()
+
+
+def test_notify_skips_build_env(
+    mocker: MockerFixture,
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("CONDA_BUILD_STATE", "BUILD")
+    ctx = mocker.patch("conda_pypi.main.context")
+    ctx.conda_prefix = str(tmp_path / "base")
+    ctx.target_prefix = str(tmp_path / "env")
+    mocker.patch("conda_pypi.main.PrefixData").return_value.query.return_value = [
+        mocker.MagicMock()
+    ]
+    mock_logger = mocker.patch("conda_pypi.main.logger")
+
+    notify_externally_managed_future("install")
+
+    mock_logger.warning.assert_not_called()
+
+
+def test_notify_skips_base_prefix(
+    mocker: MockerFixture,
+    tmp_path: Path,
+):
+    ctx = mocker.patch("conda_pypi.main.context")
+    ctx.conda_prefix = str(tmp_path / "base")
+    ctx.target_prefix = str(tmp_path / "base")
+    mocker.patch("conda_pypi.main.PrefixData").return_value.query.return_value = [
+        mocker.MagicMock()
+    ]
+    mock_logger = mocker.patch("conda_pypi.main.logger")
+
+    notify_externally_managed_future("install")
+
+    mock_logger.warning.assert_not_called()
+
+
+def test_notify_skips_no_pip(
+    mocker: MockerFixture,
+    tmp_path: Path,
+):
+    ctx = mocker.patch("conda_pypi.main.context")
+    ctx.conda_prefix = str(tmp_path / "base")
+    ctx.target_prefix = str(tmp_path / "env")
+    mocker.patch("conda_pypi.main.PrefixData").return_value.query.return_value = []
+    mock_logger = mocker.patch("conda_pypi.main.logger")
+
+    notify_externally_managed_future("install")
+
+    mock_logger.warning.assert_not_called()


### PR DESCRIPTION
### Description

Closes #353.

During the community beta (targeting conda 26.5.0), conda-pypi's `EXTERNALLY-MANAGED` marker file breaks existing `pip install` workflows and CI pipelines. This PR replaces the post-command hook that writes the PEP 668 marker file with a `logger.warning` notice that informs users about upcoming pip protection.

**What changes:**

- The `ensure_target_env_has_externally_managed` post-command hook is replaced in `plugin.py` with `notify_externally_managed_future`
- Instead of writing the `EXTERNALLY-MANAGED` file, a warning is logged on `conda create` and `conda install` (when pip is present): *"A future conda release will use PEP 668 to prevent 'pip install' in conda environments..."*
- The original `ensure_target_env_has_externally_managed` function is preserved in `main.py` for re-enablement after the beta period

**Why:**

- Bundling conda-pypi as a `run` dependency gives the beta maximum reach for community validation
- Placing the `EXTERNALLY-MANAGED` file would break the extremely common `conda activate && pip install` pattern in CI and user workflows
- The warning gives users advance notice and points them to conda-pypi's native alternatives (wheel extractor, `conda pypi install`)
- Full `EXTERNALLY-MANAGED` enforcement is planned for a later release once migration tooling is available (see conda/conda#13863, Phase 2)

**Related:**

- Epic: conda/conda#13863
- PEP 668 / EXTERNALLY-MANAGED discussion: conda/conda#15764
- ADR-001: EXTERNALLY-MANAGED File Strategy for conda-pypi Community Beta

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?