### PR TITLE
Fix repodata fn record should use exact filename

### DIFF
--- a/conda_pypi/pypi_metadata.py
+++ b/conda_pypi/pypi_metadata.py
@@ -79,7 +79,7 @@ def pypi_to_repodata(
         "build_number": 0,
         "depends": depends_list,
         "extra_depends": extra_depends_dict,
-        "fn": f"{pypi_info.get('name')}-{pypi_info.get('version')}-py3-none-any.whl",
+        "fn": wheel_url.get("filename", ""),
         "sha256": wheel_url.get("digests", {}).get("sha256", ""),
         "size": wheel_url.get("size", 0),
         "subdir": "noarch",

--- a/news/355-fix-repodata-fn-filename
+++ b/news/355-fix-repodata-fn-filename
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `pypi_to_repodata` using wrong source for `fn` field. The wheel filename is now taken from the URL entry instead of the package info dict. (#355)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_pypi_metadata.py
+++ b/tests/test_pypi_metadata.py
@@ -10,11 +10,11 @@ def test_pypi_to_repodata_requires_none_any_wheel():
         "urls": [
             {
                 "packagetype": "bdist_wheel",
-                "filename": "foo-1.0-cp312-cp312-manylinux_x86_64.whl",
-                "url": "https://example.com/wheel.whl",
+                "filename": "numpy-2.2.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                "url": "https://files.pythonhosted.org/packages/numpy-2.2.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
             }
         ],
-        "info": {"name": "foo", "version": "1.0"},
+        "info": {"name": "numpy", "version": "2.2.5"},
     }
     assert pypi_to_repodata(pypi_data) is None
 
@@ -24,15 +24,15 @@ def test_pypi_to_repodata_includes_pep508_dependency_extras():
         "urls": [
             {
                 "packagetype": "bdist_wheel",
-                "filename": "parent-1-py3-none-any.whl",
-                "url": "",
+                "filename": "certifi-2026.4.22-py3-none-any.whl",
+                "url": "https://files.pythonhosted.org/packages/certifi-2026.4.22-py3-none-any.whl",
                 "digests": {},
                 "size": 0,
             }
         ],
         "info": {
-            "name": "parent",
-            "version": "1",
+            "name": "certifi",
+            "version": "2026.4.22",
             "requires_dist": ["httpx[cli]>=0.24"],
         },
     }
@@ -46,42 +46,48 @@ def test_pypi_to_repodata_entry_minimal():
         "urls": [
             {
                 "packagetype": "bdist_wheel",
-                "filename": "foo-bar-1.0-py3-none-any.whl",
-                "url": "https://files.pythonhosted.org/foo.whl",
-                "digests": {"sha256": "abc"},
-                "size": 42,
-                "upload_time": "2024-12-06T15:37:21",
+                "filename": "importlib_metadata-9.0.0-py3-none-any.whl",
+                "url": "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl",
+                "digests": {
+                    "sha256": "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
+                },
+                "size": 27789,
+                "upload_time": "2026-03-20T06:42:55",
             }
         ],
         "info": {
-            "name": "foo_bar",
-            "version": "1.0",
+            "name": "importlib-metadata",
+            "version": "9.0.0",
             "requires_dist": [
-                'typing-extensions>=4; python_version < "3.9"',
-                'colorama>=0.4.4; sys_platform == "win32"',
-                'PySocks>=1.5.6,!=1.5.7; extra == "socks"',
+                "zipp>=3.20",
+                'pytest!=8.1.*,>=6; extra == "test"',
+                'packaging; extra == "test"',
+                'sphinx>=3.5; extra == "doc"',
             ],
-            "requires_python": ">=3.8",
+            "requires_python": ">=3.10",
         },
     }
     entry = pypi_to_repodata(pypi_data)
     assert entry is not None
-    assert entry["name"] == "foo-bar"
-    assert entry["version"] == "1.0"
+    assert entry["name"] == "importlib-metadata"
+    assert entry["version"] == "9.0.0"
     assert entry["subdir"] == "noarch"
     assert entry["noarch"] == "python"
-    assert entry["fn"] == "foo_bar-1.0-py3-none-any.whl"
-    assert entry["timestamp"] == 1733499441000
+    assert entry["fn"] == "importlib_metadata-9.0.0-py3-none-any.whl"
+    assert entry["sha256"] == "2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"
+    assert entry["size"] == 27789
+    assert entry["timestamp"] == 1773988975000
+    assert (
+        entry["url"]
+        == "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl"
+    )
 
-    assert any(d.startswith("python >=") for d in entry["depends"])
-    te_dep = next(d for d in entry["depends"] if d.startswith("typing_extensions"))
-    assert '[when="python<3.9"]' in te_dep
-    colorama_dep = next(d for d in entry["depends"] if d.startswith("colorama"))
-    assert '[when="__win"]' in colorama_dep
+    assert "zipp>=3.20" in entry["depends"]
+    assert any(d.startswith("python >=3.10") for d in entry["depends"])
 
-    socks = entry["extra_depends"]["socks"]
-    assert len(socks) == 1
-    assert socks[0].startswith("pysocks")
+    test_extra = entry["extra_depends"]["test"]
+    assert any(d.startswith("pytest") for d in test_extra)
+    assert any(d.startswith("packaging") for d in test_extra)
 
 
 def test_pypi_to_repodata_timestamp_missing_upload_time():
@@ -89,13 +95,13 @@ def test_pypi_to_repodata_timestamp_missing_upload_time():
         "urls": [
             {
                 "packagetype": "bdist_wheel",
-                "filename": "foo-1.0-py3-none-any.whl",
-                "url": "https://files.pythonhosted.org/foo.whl",
+                "filename": "certifi-2026.4.22-py3-none-any.whl",
+                "url": "https://files.pythonhosted.org/packages/certifi-2026.4.22-py3-none-any.whl",
                 "digests": {"sha256": "abc"},
                 "size": 42,
             }
         ],
-        "info": {"name": "foo", "version": "1.0"},
+        "info": {"name": "certifi", "version": "2026.4.22"},
     }
     entry = pypi_to_repodata(pypi_data)
     assert entry is not None
@@ -107,13 +113,13 @@ def test_pypi_to_repodata_appends_python_when_requires_python_missing():
         "urls": [
             {
                 "packagetype": "bdist_wheel",
-                "filename": "solo-2.0-py3-none-any.whl",
-                "url": "https://example.com/solo.whl",
+                "filename": "pytz-2026.2-py2.py3-none-any.whl",
+                "url": "https://files.pythonhosted.org/packages/pytz-2026.2-py2.py3-none-any.whl",
                 "digests": {},
                 "size": 1,
             }
         ],
-        "info": {"name": "solo", "version": "2.0", "requires_dist": []},
+        "info": {"name": "pytz", "version": "2026.2", "requires_dist": []},
     }
     entry = pypi_to_repodata(pypi_data)
     assert entry is not None
@@ -126,23 +132,23 @@ def test_pypi_to_repodata_when_condition_json_encoded():
         "urls": [
             {
                 "packagetype": "bdist_wheel",
-                "filename": "x-1-py3-none-any.whl",
-                "url": "",
+                "filename": "build-1.5.0-py3-none-any.whl",
+                "url": "https://files.pythonhosted.org/packages/build-1.5.0-py3-none-any.whl",
                 "digests": {},
                 "size": 0,
             }
         ],
         "info": {
-            "name": "x",
-            "version": "1",
-            "requires_dist": ['y; python_version < "3.11"'],
+            "name": "build",
+            "version": "1.5.0",
+            "requires_dist": ['tomli>=1.1.0; python_version < "3.11"'],
         },
     }
     entry = pypi_to_repodata(pypi_data)
     assert entry is not None
-    dep = entry["depends"][0]
+    dep = next(d for d in entry["depends"] if d.startswith("tomli"))
     prefix, when_part = dep.split("[when=", 1)
-    assert prefix.startswith("y")
+    assert prefix.startswith("tomli")
     when_inner = when_part.rstrip("]")
     # json.loads verifies quoting matches json.dumps in markers.py
     assert json.loads(when_inner) == "python<3.11"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
I noticed when comparing repodata generated by Anaconda te-repo, that our `fn:` records were incorrectly normalizing the package name and then creating a filename in the standard pure-Python format. Instead we should be using the filename directly from the wheel URL.

The tests that I added in #279 and then refactored in #341, were also using fake examples which caused this issue to not be caught. I updated the tests to use real filenames and metadata from PyPI.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
