### PR TITLE
Remove manual channel config steps (handled by condarc.d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Better PyPI interoperability for the conda ecosystem.
 
 > [!IMPORTANT]
-> This project is still in early stages of development. Don't use it in production (yet).
-> We do welcome feedback on what the expected behaviour should have been if something doesn't work!
+> This project is currently in beta. Use with caution in production environments.
+> We welcome feedback. If something doesn't work as expected, please let us know!
 
 ## Project Status
 
@@ -17,13 +17,18 @@ This is a **community-maintained** project under the [conda](https://github.com/
 
 ## What is this?
 
-Includes:
+Native support for installing wheels from PyPI using `conda install` using these steps:
+1. `conda config --set solver rattler`
+2. `conda config --set channel_priority flexible`
+3. `conda config --append channels conda-pypi`
+4. `conda install <package>`
+
+Also includes:
 
 - `conda pypi install`: Converts PyPI packages to `.conda` format for safer installation.
 - `conda pypi install -e .`: Converts a path to an editable `.conda` format package.
 - `conda pypi convert`: Convert PyPI packages to `.conda` format without installing them.
-- `conda install` from wheel channels (experimental): channels can serve pure Python wheels directly in `repodata.json`.
-- Adds `EXTERNALLY-MANAGED` to your environments.
+- A warning when running `conda create` or `conda install` with `pip` in the environment.
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ This is a **community-maintained** project under the [conda](https://github.com/
 
 ## What is this?
 
-Native support for installing wheels from PyPI using `conda install` using these steps:
+Native support for installing wheels from PyPI using `conda install`:
 1. `conda config --set solver rattler`
 2. `conda config --set channel_priority flexible`
-3. `conda config --append channels conda-pypi`
-4. `conda install <package>`
+3. `conda install <package>`
 
 Also includes:
 

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -212,7 +212,6 @@ def notify_externally_managed_future(command: str):
         "  protect conda environments from accidental 'pip install' usage.\n"
         "  Try the beta to install PyPI packages natively with conda:\n"
         "    conda config --set solver rattler\n"
-        "    conda config --append channels conda-pypi\n"
         "    conda install <package>\n"
         "  More info: https://docs.conda.io/projects/conda/en/stable/new-features.html"
     )

--- a/conda_pypi/plugin.py
+++ b/conda_pypi/plugin.py
@@ -23,7 +23,7 @@ def conda_post_commands():
     yield CondaPostCommand(
         name="conda-pypi-notify-externally-managed-future",
         action=notify_externally_managed_future,
-        run_for={"install", "create"},
+        run_for={"install", "create", "env_create"},
     )
     yield CondaPostCommand(
         name="conda-pypi-post-install-create",

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,6 +3,42 @@
 `conda-pypi` uses the `conda` plugin system to implement several features
 that make `conda` integrate better with the PyPI ecosystem:
 
+## Native wheel installation
+
+:::{admonition} Beta
+:class: warning
+
+This feature is in beta. It is based on a [draft CEP for Repodata Wheel
+Support](https://github.com/conda/ceps/pull/145) that is still under active
+discussion and subject to change. We welcome your feedback. Please share your
+experience in the [conda community channels](https://conda.org/community) or
+open an issue on [GitHub](https://github.com/conda/conda-pypi/issues).
+:::
+
+Try the beta for installing wheels from PyPI using `conda install` using these steps:
+1. `conda config --set solver rattler`
+2. `conda config --append channels conda-pypi`
+3. `conda install <package>`
+
+If you maintain a conda channel, you can also now serve Python wheels directly
+alongside regular conda packages. Add your wheels to a `v3.whl` section
+in `repodata.json` and point each entry at the wheel URL. `conda install`
+will pick them up, resolve their dependencies, and extract them correctly,
+with no pre-conversion step required.
+
+```bash
+conda install -c https://my-wheel-channel requests
+```
+
+Wheels served this way behave like any other conda package.
+
+### Extras and markers
+
+Wheels in a channel can declare [dependency specifier extras](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras)
+via an `extra_depends` field in the repodata entry.
+
+In the PyPA grammar, extras are a comma-separated list of names. Multiple extras union their requirements, and there is no reserved name meaning “all extras.” Optional extras in `extra_depends` are resolved by the Rattler solver.
+
 ## The `conda pypi` subcommand
 
 This subcommand provides a safer way to install PyPI packages in conda
@@ -76,34 +112,7 @@ checks `.dist-info/<path>` (pre-PEP 639 wheels) and `.dist-info/licenses/<path>`
 
 PyPI [environment markers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers) are translated for the solver where possible. When building installable .conda packages from wheels, `[when="…"]` is not attached to dependency strings. The `extra == "…"` marker is split into per-extra tables, and other marker conditions are omitted from depends. See {doc}`developer/marker-conversion`.
 
-## Wheel channels
 
-:::{admonition} Experimental
-:class: warning
-
-This feature is experimental. It is based on a [draft CEP for Repodata Wheel
-Support](https://github.com/conda/ceps/pull/145) that is still under active
-discussion and subject to change.
-:::
-
-If you maintain a conda channel, you can now serve Python wheels directly
-alongside regular conda packages. Add your wheels to a `v3.whl` section
-in `repodata.json` and point each entry at the wheel URL. `conda install`
-will pick them up, resolve their dependencies, and extract them correctly,
-with no pre-conversion step required.
-
-```bash
-conda install -c https://my-wheel-channel requests
-```
-
-Wheels served this way behave like any other conda package.
-
-### Extras and markers
-
-Wheels in a channel can declare [dependency specifier extras](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras)
-via an `extra_depends` field in the repodata entry.
-
-In the PyPA grammar, extras are a comma-separated list of names. Multiple extras union their requirements, and there is no reserved name meaning “all extras.” Optional extras in `extra_depends` are resolved by the Rattler solver.
 
 ## Editable Package Support
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -15,10 +15,9 @@ experience in the [conda community channels](https://conda.org/community) or
 open an issue on [GitHub](https://github.com/conda/conda-pypi/issues).
 :::
 
-Try the beta for installing wheels from PyPI using `conda install` using these steps:
+Try the beta for installing wheels from PyPI using `conda install`:
 1. `conda config --set solver rattler`
-2. `conda config --append channels conda-pypi`
-3. `conda install <package>`
+2. `conda install <package>`
 
 If you maintain a conda channel, you can also now serve Python wheels directly
 alongside regular conda packages. Add your wheels to a `v3.whl` section

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,15 +10,12 @@ by default. However, you can also install it manually:
 conda install -n base conda-pypi
 ```
 
-For the main functionality, some configuration is also required:
+The `conda-pypi` channel is configured automatically on install. For the main
+functionality, set the solver:
 
 ```bash
-# Use the rattler solver for PyPI-aware dependency resolution
 conda config --set solver rattler
-# Allow packages from different channels to mix without strict priority conflicts
 conda config --set channel_priority flexible
-# Add the conda-pypi channel for native PyPI package metadata
-conda config --append channels conda-pypi
 ```
 
 Once installed, the `conda pypi` subcommand also becomes available across all your
@@ -127,23 +124,10 @@ More details about this protection mechanism can be found at
 
 ## Uninstallation
 
-To revert the configuration changes made during installation:
+The `conda-pypi` channel mapping is removed automatically when the package is
+uninstalled. To also revert solver settings:
 
 ```bash
-# Remove the conda-pypi channel
-conda config --remove channels conda-pypi
-
-# Revert the solver and channel priority to the conda defaults
 conda config --remove-key solver
 conda config --remove-key channel_priority
 ```
-
-If you set `rattler` or `channel_priority` for reasons unrelated to `conda-pypi`,
-skip those `--remove-key` steps to keep your existing configuration. If you prefer
-to restore `channel_priority` to `strict` rather than the default, use:
-
-```bash
-conda config --set channel_priority strict
-```
-
-Note that `strict` channel priority may cause dependency resolution failures.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,21 +3,44 @@
 ## Installation
 
 `conda-pypi` is a `conda` plugin that needs to be installed next to
-`conda` in the `base` environment:
+`conda` in the `base` environment. Starting with `conda` 26.5.0, it is installed
+by default. However, you can also install it manually:
 
 ```bash
 conda install -n base conda-pypi
 ```
 
-Once installed, the `conda pypi` subcommand becomes available across all your
+For the main functionality, some configuration is also required:
+
+```bash
+# Use the rattler solver for PyPI-aware dependency resolution
+conda config --set solver rattler
+# Allow packages from different channels to mix without strict priority conflicts
+conda config --set channel_priority flexible
+# Add the conda-pypi channel for native PyPI package metadata
+conda config --append channels conda-pypi
+```
+
+Once installed, the `conda pypi` subcommand also becomes available across all your
 conda environments.
 
 ## Basic usage
 
 `conda-pypi` provides several {doc}`features`. The main functionality is
-accessed through the `conda pypi` command:
+accessed through the normal `conda install` command:
 
-### Installing PyPI packages
+### Native PyPI package support
+
+```bash
+conda install django-modern-rest
+```
+
+This will natively install the wheels for `django-modern-rest` from PyPI to your current
+environment. Since it is a native installation served by metadata from the `conda-pypi`
+channel, all other features of conda should work the same as installing any other
+`.conda` package.
+
+### Installing PyPI packages through conversion
 
 Assuming you have an activated conda environment named `my-python-env` that
 includes `python` and `pip` installed, and a configured conda channel, you can
@@ -101,3 +124,26 @@ a `conda pypi` command on them.
 
 More details about this protection mechanism can be found at
 {ref}`externally-managed`.
+
+## Uninstallation
+
+To revert the configuration changes made during installation:
+
+```bash
+# Remove the conda-pypi channel
+conda config --remove channels conda-pypi
+
+# Revert the solver and channel priority to the conda defaults
+conda config --remove-key solver
+conda config --remove-key channel_priority
+```
+
+If you set `rattler` or `channel_priority` for reasons unrelated to `conda-pypi`,
+skip those `--remove-key` steps to keep your existing configuration. If you prefer
+to restore `channel_priority` to `strict` rather than the default, use:
+
+```bash
+conda config --set channel_priority strict
+```
+
+Note that `strict` channel priority may cause dependency resolution failures.


### PR DESCRIPTION
Stacked on #352. Removes the manual `conda config --append channels conda-pypi` step from docs and the warning message.

The conda-pypi feedstock PRs (AnacondaRecipes/conda-pypi-feedstock#12, conda-forge/conda-pypi-feedstock#47) ship a `condarc.d/conda-pypi.yml` config fragment into the prefix at build time. This means the channel mapping is automatic on install and removed on uninstall. No manual channel config steps needed.

Changes:
- **README.md**: Setup goes from 4 steps to 3 (channel append removed)
- **conda_pypi/main.py**: Warning message no longer tells users to add the channel
- **docs/features.md**: Same step removed from the beta instructions
- **docs/quickstart.md**: Installation section notes the channel is auto-configured; uninstallation section simplified since the channel mapping is cleaned up automatically

Depends on the feedstock PRs landing first. See conda/conda-pypi#358 for background.
