### PR TITLE
Add docstrings to Pixi tasks

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11686,8 +11686,8 @@ packages:
   timestamp: 1751548225624
 - pypi: ./
   name: conda-pypi
-  version: 0.8.1.dev11+g80d5d15c7
-  sha256: 7a5b4a9372d170a92ba515550cf3ed9ec15d3883c3ac646185cf88670e227fe0
+  version: 0.1.dev228+ga30866c1f.d20260518
+  sha256: a78d1a3622aa9a5ab6feec4e3f14390054744bafbb8cf3ac22375c9203e0cdef
   requires_dist:
   - build
   - conda-index>=0.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ sphinx-reredirects = "*"
 sphinx-sitemap = "*"
 
 [tool.pixi.feature.test.tasks.test]
- cmd = 'python -m pytest -m "not benchmark"'
+cmd = 'python -m pytest -m "not benchmark"'
 description = "Run the test suite using pytest, excluding benchmarks. This calls task `dev` first to ensure the environment is set up correctly for testing."
 depends-on = ["dev"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,25 +61,51 @@ unearth = "*"
 [tool.pixi.pypi-dependencies]
 "conda-pypi" = { path  = ".", editable = true }
 
-[tool.pixi.tasks]
-dev = 'python -c "from conda_pypi.python_paths import ensure_externally_managed as e; e()"'
+[tool.pixi.tasks.dev]
+cmd = 'python -c "from conda_pypi.python_paths import ensure_externally_managed as e; e()"'
+description = """Set up the environment for development
+            This calls `conda_pypi.python_paths.ensure_externally_managed`:
+                    conda-pypi places its own EXTERNALLY-MANAGED file when it is installed in an environment.
+                    We also need to place it in _new_ environments created by conda. We do this by
+                    implementing some extra plugin hooks."""
 
 [tool.pixi.feature.build]
 dependencies = { anaconda-client = "*", conda-build = "*" }
-tasks = { build = "conda build recipe" }
+
+[tool.pixi.feature.build.tasks.build]
+cmd = "conda build recipe"
+description = "Build conda packages using conda-build. The recipe should be located in the `recipe/` directory."
 
 [tool.pixi.feature.lint.dependencies]
 python = "3.12.*"
 pre-commit = "*"
 
-[tool.pixi.feature.lint.tasks]
-lint = "pre-commit"
-pre-commit = "pre-commit"
+[tool.pixi.feature.lint.tasks.pre-commit]
+cmd = "pre-commit"
+description = "Run pre-commit hooks to lint the codebase."
 
-[tool.pixi.feature.docs.tasks]
-docs = { cmd = "sphinx-build -M dirhtml . _build", cwd = "docs" }
-serve = { cmd = "python -m http.server", cwd = "docs/_build/dirhtml" }
-clean = { cmd = "rm -rf _build", cwd = "docs" }
+[tool.pixi.feature.lint.tasks.lint]
+cmd = "pre-commit"
+description = "Run pre-commit hooks to lint the codebase. Alias for `pre-commit` task."
+
+[tool.pixi.feature.docs.tasks.build-docs]
+cmd = "sphinx-build -M dirhtml . _build"
+cwd = "docs"
+description = "Build the documentation using Sphinx. The output will be in docs/_build/dirhtml"
+
+[tool.pixi.feature.docs.tasks.serve-docs]
+cmd = "python -m http.server"
+cwd = "docs/_build/dirhtml"
+description = "Serve the built documentation locally at http://localhost:8000/ Run `pixi docs` first to build the documentation before serving it."
+
+[tool.pixi.feature.docs.tasks.make-docs]
+depends-on = ["build-docs", "serve-docs"]
+description = "Build the documentation and serve it locally at http://localhost:8000/ Runs tasks `build-docs` and `serve-docs` in one step."
+
+[tool.pixi.feature.docs.tasks.clean-docs]
+cmd = "rm -rf _build"
+cwd = "docs"
+description = "Clean the documentation build directory"
 
 [tool.pixi.feature.docs.dependencies]
 python = "3.10.*"
@@ -93,9 +119,16 @@ sphinx-design = "*"
 sphinx-reredirects = "*"
 sphinx-sitemap = "*"
 
-[tool.pixi.feature.test.tasks]
-test = 'python -c "from conda_pypi.python_paths import ensure_externally_managed as e; e()" && python -mpytest -m "not benchmark"'
-benchmark= 'python -c "from conda_pypi.python_paths import ensure_externally_managed as e; e()" && python -mpytest --codspeed'
+[tool.pixi.feature.test.tasks.test]
+ cmd = 'python -m pytest -m "not benchmark"'
+description = "Run the test suite using pytest, excluding benchmarks. This calls task `dev` first to ensure the environment is set up correctly for testing."
+depends-on = ["dev"]
+
+[tool.pixi.feature.test.tasks.benchmark]
+cmd = "python -mpytest --codspeed"
+description = "Run the benchmark tests using pytest-codspeed. This calls task `dev` first to ensure the environment is set up correctly for testing."
+depends-on = ["dev"]
+
 
 [tool.pixi.feature.test.dependencies]
 pytest = "7.4.3.*"


### PR DESCRIPTION
### Description

All tasks in pixi now have docstrings, which will be displayed when running `pixi task list`. This should make it easier for users to understand what each task does and how to use it. All task TOML tables use the long form instead of inline tables, i.e. they are written as:
```toml
[tool.pixi.tasks.task_name]
cmd = ...
```
instead of:

```toml
[tool.pixi.tasks]
task_name = { cmd = "..." }
````

Some tasks where renamed. For example `serve` was renamed to `serve-docs` and `docs` was renamed to `build-docs`. In addition, duplicated commands where replaced with `depends-on`, for example:

```toml
[tool.pixi.feature.test.tasks.test]
...
depends-on = ["dev"]
```

instead of repeating the command from `[tool.pixi.tasks.dev]`.

No functionality was added, removed, or changed. This is purely a documentation update. One exception is:

```toml
[tool.pixi.feature.docs.tasks.make-docs]
depends-on = ["build-docs", "serve-docs"]
```

that adds a new compound command that calls to existing tasks. This is not strictly necessary, but it provides a convenient way to build and serve the docs with a single command.

There no tests for Pixi tasks. So, no new test were added. 

### Checklist

- [- ] Add / update necessary tests? --> no tests for tasks
- [x ] Add / update outdated documentation? --> for tasks



