### PR TITLE
Add Zulip link, remove Element and Discourse links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,26 +99,6 @@ html_theme_options = {
     "navigation_depth": -1,
     "use_edit_page_button": True,
     "navbar_center": ["navbar_center"],
-    "icon_links": [
-        {
-            "name": "GitHub",
-            "url": "https://github.com/conda/conda-pypi",
-            "icon": "fa-brands fa-square-github",
-            "type": "fontawesome",
-        },
-        {
-            "name": "Element",
-            "url": "https://matrix.to/#/#conda_conda:gitter.im",
-            "icon": "_static/element_logo.svg",
-            "type": "local",
-        },
-        {
-            "name": "Discourse",
-            "url": "https://conda.discourse.group/",
-            "icon": "fa-brands fa-discourse",
-            "type": "fontawesome",
-        },
-    ],
 }
 
 html_context = {


### PR DESCRIPTION
### Description

Removing `"icon_links"` from the Sphinx theme options in `conf.py` uses the defaults from `"conda_sphinx_theme"`, which includes a Zulip link and removes the Element and Discourse links.


### Checklist

- [x] No new file added
- [x] No tests --> changes in Sphinx configuration only
- [x] Update documentation theme

Closes #311.
