### PR TITLE
Remove CLI `__main__` module since not useful for a plugin

### DIFF
--- a/conda_pypi/__main__.py
+++ b/conda_pypi/__main__.py
@@ -1,6 +1,0 @@
-import sys
-
-from conda.cli.main import main_subshell
-
-if __name__ == "__main__":
-    sys.exit(main_subshell("pip", *sys.argv[1:]))


### PR DESCRIPTION
### Description

Since `conda-pypi` is a [pluggy](https://github.com/pytest-dev/pluggy)-based plugin for `conda`, it doesn't make sense for it to have a CLI of its own. Removing `conda_pypi/__main__.py`, which was the entry point for the CLI, and instead relying on the plugin system to integrate with `conda`'s CLI directly.

### Checklist 

- [x] No files added, remove one
- [x] No tests needed, only remove a feature
- [x] No documentation needed