### PR TITLE
Add missing metadata to `about.json`

### DIFF
--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -26,7 +26,6 @@ from conda.common.path.windows import win_path_to_unix
 from conda_package_streaming.create import conda_builder
 from installer.utils import parse_wheel_filename
 
-
 from conda_pypi import dependencies, installer, paths
 from conda_pypi.conda_build_utils import PathType, sha256_checksum
 from conda_pypi.license_files import copy_into_info_licenses

--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -18,12 +18,14 @@ import tempfile
 import zipfile
 from importlib.metadata import PathDistribution
 from pathlib import Path
+from typing import Iterable
 
 from build import ProjectBuilder
 from conda.common.compat import on_win
 from conda.common.path.windows import win_path_to_unix
 from conda_package_streaming.create import conda_builder
 from installer.utils import parse_wheel_filename
+
 
 from conda_pypi import dependencies, installer, paths
 from conda_pypi.conda_build_utils import PathType, sha256_checksum
@@ -152,6 +154,7 @@ def build_conda(
     test_dir: Path | None = None,
     is_editable=False,
     pypi_to_conda_name_mapping: dict | None = None,
+    channels: Iterable[str] = (),
 ) -> Path:
     if not build_path.exists():
         build_path.mkdir()
@@ -175,7 +178,9 @@ def build_conda(
         # straightforward to write or find a WheelDistribution() to grab these
         # files from the wheel archive directly, instead of PathDistribution():
         metadata = CondaMetadata.from_distribution(
-            PathDistribution(dist_info), pypi_to_conda_name_mapping
+            PathDistribution(dist_info),
+            pypi_to_conda_name_mapping,
+            channels=channels,
         )
         record = metadata.package_record.to_index_json()
         file_id = f"{record['name']}-{record['version']}-{record['build']}"
@@ -276,6 +281,7 @@ def pypa_to_conda(
     output_path: Path | None = None,
     test_dir: Path | None = None,
     pypi_to_conda_name_mapping: dict | None = None,
+    channels: Iterable[str] = (),
 ):
     project = Path(project)
 
@@ -303,6 +309,7 @@ def pypa_to_conda(
             test_dir=test_dir,
             is_editable=distribution == "editable",
             pypi_to_conda_name_mapping=pypi_to_conda_name_mapping,
+            channels=channels,
         )
 
     return package_conda

--- a/conda_pypi/cli/convert.py
+++ b/conda_pypi/cli/convert.py
@@ -142,6 +142,7 @@ def execute(args: Namespace) -> int:
                 python_executable,
                 test_dir=test_dir,
                 pypi_to_conda_name_mapping=pypi_to_conda_name_mapping,
+                channels=tuple(context.channels),
             )
     else:
         # Build from source (project directory or sdist)

--- a/conda_pypi/cli/convert.py
+++ b/conda_pypi/cli/convert.py
@@ -153,6 +153,7 @@ def execute(args: Namespace) -> int:
             prefix=prefix_path,
             test_dir=test_dir,
             pypi_to_conda_name_mapping=pypi_to_conda_name_mapping,
+            channels=tuple(context.channels),
         )
 
     print(f"Conda package at {package_path} built successfully. Output folder: {output_folder}.")

--- a/conda_pypi/cli/install.py
+++ b/conda_pypi/cli/install.py
@@ -115,6 +115,7 @@ def execute(args: Namespace) -> int:
                 distribution="editable",
                 output_path=Path(output_path),
                 prefix=prefix_path,
+                channels=() if args.ignore_channels else tuple(context.channels),
             )
             installer.install_ephemeral_conda(prefix_path, package)
         return 0

--- a/conda_pypi/convert_tree.py
+++ b/conda_pypi/convert_tree.py
@@ -9,7 +9,7 @@ import pathlib
 import re
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Union
 
 if TYPE_CHECKING:
     from conda.core.solve import Solver
@@ -82,6 +82,7 @@ class ConvertTree:
         max_attempts: int,
         solver: Solver,
         tmp_path: Path,
+        channels: Iterable[str] = (),
     ) -> tuple[tuple[PrefixRecord, ...], tuple[PrefixRecord, ...]] | None:
         converted = set()
         fetched_packages = set()
@@ -127,6 +128,7 @@ class ConvertTree:
                         repo / "noarch",  # XXX could be arch
                         self.python_exe,
                         is_editable=False,
+                        channels=channels,
                     )
                     log.debug("Conda at", package_conda)
                 except FileExistsError:
@@ -198,8 +200,10 @@ class ConvertTree:
 
             if not self.override_channels:
                 channels = [local_channel, *context.channels]
+                build_channels = tuple(context.channels)
             else:  # more wheels for us to convert
                 channels = [local_channel]
+                build_channels = ()
 
             solver_backend = context.plugin_manager.get_cached_solver_backend()
             solver = solver_backend(
@@ -218,7 +222,10 @@ class ConvertTree:
             with get_spinner(self._get_converting_spinner_message(channels)):
                 with fresh_context(env=context_env):
                     changes = self._convert_loop(
-                        max_attempts=max_attempts, solver=solver, tmp_path=tmp_path
+                        max_attempts=max_attempts,
+                        solver=solver,
+                        tmp_path=tmp_path,
+                        channels=build_channels,
                     )
 
             return changes

--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -15,6 +15,7 @@ from conda.exceptions import ArgumentError
 from conda.models.match_spec import MatchSpec
 from packaging.requirements import Requirement
 
+from conda_pypi import __version__
 from conda_pypi.name_mapping import conda_to_pypi_name, pypi_to_conda_name
 
 log = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ URL_LABEL_MAP: Dict[str, tuple] = {
 }
 
 
-def _short_description(text: str) -> str:
+def short_description(text: str) -> str:
     """
     Truncate a long Description to its first paragraph.
 
@@ -56,7 +57,7 @@ def _short_description(text: str) -> str:
     return "\n".join(lines).strip()
 
 
-def _url_from_project_urls(metadata: PackageMetadata, labels: Iterable[str]) -> Optional[str]:
+def url_from_project_urls(metadata: PackageMetadata, labels: Iterable[str]) -> Optional[str]:
     """Return the first Project-URL value whose label (case-insensitive) is in `labels`."""
     wanted = {label.lower() for label in labels}
     for entry in metadata.get_all("project-url") or ():
@@ -182,13 +183,13 @@ class CondaMetadata:
 
         about: Dict[str, Any] = {
             "summary": metadata.get("summary") or "",
-            "description": _short_description(metadata.get("description") or ""),
+            "description": short_description(metadata.get("description") or ""),
             # https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression
             "license": metadata.get("License-Expression") or metadata.get("License") or "",
         }
 
         for conda_field, labels in URL_LABEL_MAP.items():
-            url = _url_from_project_urls(metadata, labels)
+            url = url_from_project_urls(metadata, labels)
             if url:
                 about[conda_field] = url
 
@@ -215,9 +216,6 @@ class CondaMetadata:
             timestamp=time.time_ns() // 1000000,
         )
 
-        # Provenance lives under `extra` (CEP 34 allows arbitrary metadata there).
-        from conda_pypi import __version__ as _conda_pypi_version
-
         about["extra"] = {
             "recipe": {
                 "name": package_record.name,
@@ -225,7 +223,7 @@ class CondaMetadata:
                 "build": package_record.build,
             },
             "generator": "conda-pypi",
-            "generator_version": _conda_pypi_version,
+            "generator_version": __version__,
         }
 
         return cls(

--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -4,11 +4,12 @@ Convert Python `*.dist-info/METADATA` to conda `info/index.json`
 
 import dataclasses
 import logging
+import re
 import sys
 import time
 from importlib.metadata import Distribution, PackageMetadata, PathDistribution
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from conda.exceptions import ArgumentError
 from conda.models.match_spec import MatchSpec
@@ -17,6 +18,52 @@ from packaging.requirements import Requirement
 from conda_pypi.name_mapping import conda_to_pypi_name, pypi_to_conda_name
 
 log = logging.getLogger(__name__)
+
+# Project-URL label (case-insensitive) → about.json field.
+# First matching label wins.
+URL_LABEL_MAP: Dict[str, tuple] = {
+    "home": ("homepage", "home", "home-page"),
+    "dev_url": ("source", "repository", "source code", "development", "github"),
+    "doc_url": ("documentation", "docs"),
+}
+
+
+def _short_description(text: str) -> str:
+    """
+    Truncate a long Description to its first paragraph.
+
+    Stops at the first blank line or the first Markdown heading
+    (`#`, setext underline of `=` or `-`), so README+CHANGELOG dumps
+    don't end up in about.json.
+    """
+    if not text:
+        return ""
+    # email.parser un-indents the continuation lines but may leave a leading
+    # space on each line; strip uniformly.
+    lines: List[str] = []
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        stripped = line.lstrip()
+        if not stripped:
+            break
+        if stripped.startswith("#"):
+            break
+        if lines and re.fullmatch(r"[=\-]{3,}", stripped):
+            # setext heading underline for the previous line
+            lines.pop()
+            break
+        lines.append(stripped)
+    return "\n".join(lines).strip()
+
+
+def _url_from_project_urls(metadata: PackageMetadata, labels: Iterable[str]) -> Optional[str]:
+    """Return the first Project-URL value whose label (case-insensitive) is in `labels`."""
+    wanted = {label.lower() for label in labels}
+    for entry in metadata.get_all("project-url") or ():
+        label, _, url = entry.partition(", ")
+        if label.strip().lower() in wanted:
+            return url.strip()
+    return None
 
 
 class FileDistribution(Distribution):
@@ -102,7 +149,10 @@ class CondaMetadata:
 
     @classmethod
     def from_distribution(
-        cls, distribution: Distribution, pypi_to_conda_name_mapping: dict | None = None
+        cls,
+        distribution: Distribution,
+        pypi_to_conda_name_mapping: dict | None = None,
+        channels: Iterable[str] = (),
     ):
         metadata = distribution.metadata
 
@@ -130,22 +180,21 @@ class CondaMetadata:
         # 'keywords', 'license', 'license_family', 'license_file', 'root_pkgs',
         # 'summary', 'tags', 'conda_private', 'doc_source_url', 'license_url']
 
-        about = {
+        about: Dict[str, Any] = {
             "summary": metadata.get("summary") or "",
-            "description": metadata.get("description") or "",
+            "description": _short_description(metadata.get("description") or ""),
             # https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression
             "license": metadata.get("License-Expression") or metadata.get("License") or "",
         }
 
-        if project_urls := metadata.get_all("project-url"):
-            urls = dict(url.split(", ", 1) for url in project_urls)
-            for py_name, conda_name in (
-                ("Home", "home"),
-                ("Development", "dev_url"),
-                ("Documentation", "doc_url"),
-            ):
-                if py_name in urls:
-                    about[conda_name] = urls[py_name]
+        for conda_field, labels in URL_LABEL_MAP.items():
+            url = _url_from_project_urls(metadata, labels)
+            if url:
+                about[conda_field] = url
+
+        channels_list = list(channels)
+        if channels_list:
+            about["channels"] = channels_list
 
         name = pypi_to_conda_name(
             getattr(distribution, "name", None) or distribution.metadata.get("name"),
@@ -165,6 +214,19 @@ class CondaMetadata:
             noarch=noarch,
             timestamp=time.time_ns() // 1000000,
         )
+
+        # Provenance lives under `extra` (CEP 34 allows arbitrary metadata there).
+        from conda_pypi import __version__ as _conda_pypi_version
+
+        about["extra"] = {
+            "recipe": {
+                "name": package_record.name,
+                "version": package_record.version,
+                "build": package_record.build,
+            },
+            "generator": "conda-pypi",
+            "generator_version": _conda_pypi_version,
+        }
 
         return cls(
             metadata=metadata,

--- a/news/343-include-missing-about-json-metadata
+++ b/news/343-include-missing-about-json-metadata
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Populate additional `info/about.json` fields (`home`, `dev_url`, `doc_url`, `channels`, `extra.recipe`, `extra.generator`) when converting PyPI projects, and truncate `description` to the first paragraph to avoid embedding the full README + CHANGELOG. (#343)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -3,6 +3,7 @@ import os
 
 import conda_package_streaming.package_streaming as cps
 import pytest
+from conda.base.context import context
 from conda.cli.main import main_subshell
 from conda.common.compat import on_win
 from conda.exceptions import ArgumentError
@@ -15,6 +16,13 @@ PKG_TEST_DIR = "tests/packages/has-test-dir/test"
 
 # Expected output paths
 EXPECTED_TEST_SCRIPT = "info/test/run_test.bat" if on_win else "info/test/run_test.sh"
+
+
+def _read_about_json(package_path):
+    for tar, member in cps.stream_conda_info(str(package_path)):
+        if member.name == "info/about.json":
+            return json.load(tar.extractfile(member))
+    raise AssertionError("info/about.json not found")
 
 
 @pytest.mark.parametrize(
@@ -55,6 +63,7 @@ def test_convert_wheel(tmp_path):
     assert files[0].is_file()
     assert os.path.getsize(files[0]) > 0
     assert "demo-package" in files[0].name
+    assert _read_about_json(files[0])["channels"] == list(context.channels)
 
 
 def test_convert_wheel_with_tests(tmp_path):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -112,6 +112,40 @@ def test_build_conda_copies_licenses_to_info_licenses(
     assert lic_payload == b"BSD-3-Clause placeholder license text\n"
 
 
+def test_build_conda_records_channels_in_about_json(
+    tmp_env: TmpEnvFixture,
+    pypi_demo_package_wheel_path: Path,
+    tmp_path: Path,
+):
+    """Channels passed to build_conda are recorded in info/about.json (#343)."""
+    build_path = tmp_path / "build"
+    build_path.mkdir()
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    target = repo_path / "demo-package-0.1.0-pypi_0.conda"
+
+    with tmp_env("python=3.12", "pip") as prefix:
+        build_conda(
+            pypi_demo_package_wheel_path,
+            build_path,
+            repo_path,
+            Path(prefix, get_python_short_path()),
+            is_editable=False,
+            channels=("conda-forge", "bioconda"),
+        )
+
+    about = None
+    for tar, member in package_streaming.stream_conda_info(target):
+        if member.name == "info/about.json":
+            about = json.load(tar.extractfile(member))
+            break
+    assert about is not None
+    assert about["channels"] == ["conda-forge", "bioconda"]
+    assert about["extra"]["generator"] == "conda-pypi"
+    assert about["extra"]["recipe"]["name"] == "demo-package"
+    assert about["extra"]["recipe"]["build"] == "pypi_0"
+
+
 def test_build_conda_members_stay_in_info_component(
     pypi_demo_package_wheel_path: Path,
     tmp_path: Path,

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -3,6 +3,7 @@
 import pytest
 from conda.exceptions import ArgumentError
 
+from conda_pypi import __version__
 from conda_pypi.translate import (
     CondaMetadata,
     FileDistribution,
@@ -140,98 +141,51 @@ def test_requires_to_conda_marker_extra_and_platform():
     assert requires == []
 
 
-# --- about.json improvements (issue #343) ---
-
-
-def _distribution(**project_urls):
+def _distribution(project_urls=(), description=None):
     """Build a FileDistribution with the given Project-URL labels."""
-    header = "Metadata-Version: 2.1\nName: demo\nVersion: 1.0.0\nSummary: short summary\n"
-    urls = "".join(f"Project-URL: {label}, {url}\n" for label, url in project_urls.items())
-    return FileDistribution(header + urls + "\n")
+    header = [
+        "Metadata-Version: 2.1\n",
+        "Name: demo\n",
+        "Version: 1.0.0\n",
+        "Summary: short summary\n",
+    ]
+    if description is not None:
+        header.append("Description: " + description.replace("\n", "\n        ") + "\n")
+    urls = "".join(f"Project-URL: {label}, {url}\n" for label, url in project_urls)
+    return FileDistribution("".join(header) + urls + "\n")
 
 
-def test_about_home_from_homepage_label():
-    """`Homepage` (PEP 621) maps to about.home."""
-    dist = _distribution(Homepage="https://example.com/")
+@pytest.mark.parametrize(
+    ("label", "field", "url"),
+    [
+        ("Homepage", "home", "https://example.com/"),
+        ("Home", "home", "https://example.com/"),
+        ("HOMEPAGE", "home", "https://example.com/"),
+        ("Source", "dev_url", "https://github.com/example/demo"),
+        ("Repository", "dev_url", "https://github.com/example/demo"),
+        ("Documentation", "doc_url", "https://demo.readthedocs.io"),
+        ("Docs", "doc_url", "https://demo.readthedocs.io"),
+    ],
+)
+def test_about_url_fields_from_project_url_labels(label, field, url):
+    dist = _distribution(project_urls=[(label, url)])
     about = CondaMetadata.from_distribution(dist).about
-    assert about["home"] == "https://example.com/"
+    assert about[field] == url
 
 
-def test_about_home_from_legacy_home_label():
-    """Legacy `Home` label still maps to about.home."""
-    dist = _distribution(Home="https://example.com/")
+@pytest.mark.parametrize(
+    ("description", "expected"),
+    [
+        ("Demo project.\n\n## Changelog\n\n- 1.0.0: initial release\n", "Demo project."),
+        ("Demo project.\n# Heading\nMore text.\n", "Demo project."),
+        ("Demo project.\nHeading\n---\nMore text.\n", "Demo project."),
+        ("One line of prose.", "One line of prose."),
+    ],
+)
+def test_about_description_is_shortened(description, expected):
+    dist = _distribution(description=description)
     about = CondaMetadata.from_distribution(dist).about
-    assert about["home"] == "https://example.com/"
-
-
-def test_about_home_label_is_case_insensitive():
-    """Label lookup ignores case (`HOMEPAGE`, `homepage`, `Homepage` are equivalent)."""
-    dist = _distribution(HOMEPAGE="https://example.com/")
-    about = CondaMetadata.from_distribution(dist).about
-    assert about["home"] == "https://example.com/"
-
-
-def test_about_dev_url_from_source_label():
-    """`Source` maps to about.dev_url."""
-    dist = _distribution(Source="https://github.com/example/demo")
-    about = CondaMetadata.from_distribution(dist).about
-    assert about["dev_url"] == "https://github.com/example/demo"
-
-
-def test_about_dev_url_from_repository_label():
-    """`Repository` maps to about.dev_url."""
-    dist = _distribution(Repository="https://github.com/example/demo")
-    about = CondaMetadata.from_distribution(dist).about
-    assert about["dev_url"] == "https://github.com/example/demo"
-
-
-def test_about_doc_url_from_documentation_label():
-    """`Documentation` maps to about.doc_url."""
-    dist = _distribution(Documentation="https://demo.readthedocs.io")
-    about = CondaMetadata.from_distribution(dist).about
-    assert about["doc_url"] == "https://demo.readthedocs.io"
-
-
-def test_about_doc_url_from_docs_label():
-    """`Docs` (short form) maps to about.doc_url."""
-    dist = _distribution(Docs="https://demo.readthedocs.io")
-    about = CondaMetadata.from_distribution(dist).about
-    assert about["doc_url"] == "https://demo.readthedocs.io"
-
-
-def test_about_description_truncates_at_first_blank_line():
-    """A multi-paragraph description is truncated to the first paragraph."""
-    description = "Demo project.\n\n## Changelog\n\n- 1.0.0: initial release\n"
-    dist = FileDistribution(
-        "Metadata-Version: 2.1\n"
-        "Name: demo\n"
-        "Version: 1.0.0\n"
-        "Description: " + description.replace("\n", "\n        ") + "\n"
-    )
-    about = CondaMetadata.from_distribution(dist).about
-    assert about["description"] == "Demo project."
-
-
-def test_about_description_truncates_at_markdown_heading():
-    """A description with an inline Markdown heading stops at the heading."""
-    description = "Demo project.\n# Heading\nMore text.\n"
-    dist = FileDistribution(
-        "Metadata-Version: 2.1\n"
-        "Name: demo\n"
-        "Version: 1.0.0\n"
-        "Description: " + description.replace("\n", "\n        ") + "\n"
-    )
-    about = CondaMetadata.from_distribution(dist).about
-    assert about["description"] == "Demo project."
-
-
-def test_about_description_single_paragraph_unchanged():
-    """A single-paragraph description survives truncation unchanged."""
-    dist = FileDistribution(
-        "Metadata-Version: 2.1\nName: demo\nVersion: 1.0.0\nDescription: One line of prose.\n"
-    )
-    about = CondaMetadata.from_distribution(dist).about
-    assert about["description"] == "One line of prose."
+    assert about["description"] == expected
 
 
 def test_about_channels_recorded_when_passed():
@@ -259,9 +213,7 @@ def test_about_extra_recipe_records_name_version_build():
 
 def test_about_extra_generator_records_conda_pypi_version():
     """about.extra.generator records 'conda-pypi' and its version."""
-    import conda_pypi
-
     dist = _distribution()
     about = CondaMetadata.from_distribution(dist).about
     assert about["extra"]["generator"] == "conda-pypi"
-    assert about["extra"]["generator_version"] == conda_pypi.__version__
+    assert about["extra"]["generator_version"] == __version__

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -145,12 +145,7 @@ def test_requires_to_conda_marker_extra_and_platform():
 
 def _distribution(**project_urls):
     """Build a FileDistribution with the given Project-URL labels."""
-    header = (
-        "Metadata-Version: 2.1\n"
-        "Name: demo\n"
-        "Version: 1.0.0\n"
-        "Summary: short summary\n"
-    )
+    header = "Metadata-Version: 2.1\nName: demo\nVersion: 1.0.0\nSummary: short summary\n"
     urls = "".join(f"Project-URL: {label}, {url}\n" for label, url in project_urls.items())
     return FileDistribution(header + urls + "\n")
 
@@ -206,13 +201,7 @@ def test_about_doc_url_from_docs_label():
 
 def test_about_description_truncates_at_first_blank_line():
     """A multi-paragraph description is truncated to the first paragraph."""
-    description = (
-        "Demo project.\n"
-        "\n"
-        "## Changelog\n"
-        "\n"
-        "- 1.0.0: initial release\n"
-    )
+    description = "Demo project.\n\n## Changelog\n\n- 1.0.0: initial release\n"
     dist = FileDistribution(
         "Metadata-Version: 2.1\n"
         "Name: demo\n"
@@ -239,10 +228,7 @@ def test_about_description_truncates_at_markdown_heading():
 def test_about_description_single_paragraph_unchanged():
     """A single-paragraph description survives truncation unchanged."""
     dist = FileDistribution(
-        "Metadata-Version: 2.1\n"
-        "Name: demo\n"
-        "Version: 1.0.0\n"
-        "Description: One line of prose.\n"
+        "Metadata-Version: 2.1\nName: demo\nVersion: 1.0.0\nDescription: One line of prose.\n"
     )
     about = CondaMetadata.from_distribution(dist).about
     assert about["description"] == "One line of prose."
@@ -251,9 +237,7 @@ def test_about_description_single_paragraph_unchanged():
 def test_about_channels_recorded_when_passed():
     """Channels passed to from_distribution land in about.channels."""
     dist = _distribution()
-    about = CondaMetadata.from_distribution(
-        dist, channels=("conda-forge", "bioconda")
-    ).about
+    about = CondaMetadata.from_distribution(dist, channels=("conda-forge", "bioconda")).about
     assert about["channels"] == ["conda-forge", "bioconda"]
 
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -3,7 +3,12 @@
 import pytest
 from conda.exceptions import ArgumentError
 
-from conda_pypi.translate import requires_to_conda, validate_name_mapping_format
+from conda_pypi.translate import (
+    CondaMetadata,
+    FileDistribution,
+    requires_to_conda,
+    validate_name_mapping_format,
+)
 
 
 def test_validate_name_mapping_format_valid():
@@ -133,3 +138,146 @@ def test_requires_to_conda_marker_extra_and_platform():
     assert "dev" in extras
     assert any(x.startswith("requests>=") for x in extras["dev"])
     assert requires == []
+
+
+# --- about.json improvements (issue #343) ---
+
+
+def _distribution(**project_urls):
+    """Build a FileDistribution with the given Project-URL labels."""
+    header = (
+        "Metadata-Version: 2.1\n"
+        "Name: demo\n"
+        "Version: 1.0.0\n"
+        "Summary: short summary\n"
+    )
+    urls = "".join(f"Project-URL: {label}, {url}\n" for label, url in project_urls.items())
+    return FileDistribution(header + urls + "\n")
+
+
+def test_about_home_from_homepage_label():
+    """`Homepage` (PEP 621) maps to about.home."""
+    dist = _distribution(Homepage="https://example.com/")
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["home"] == "https://example.com/"
+
+
+def test_about_home_from_legacy_home_label():
+    """Legacy `Home` label still maps to about.home."""
+    dist = _distribution(Home="https://example.com/")
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["home"] == "https://example.com/"
+
+
+def test_about_home_label_is_case_insensitive():
+    """Label lookup ignores case (`HOMEPAGE`, `homepage`, `Homepage` are equivalent)."""
+    dist = _distribution(HOMEPAGE="https://example.com/")
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["home"] == "https://example.com/"
+
+
+def test_about_dev_url_from_source_label():
+    """`Source` maps to about.dev_url."""
+    dist = _distribution(Source="https://github.com/example/demo")
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["dev_url"] == "https://github.com/example/demo"
+
+
+def test_about_dev_url_from_repository_label():
+    """`Repository` maps to about.dev_url."""
+    dist = _distribution(Repository="https://github.com/example/demo")
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["dev_url"] == "https://github.com/example/demo"
+
+
+def test_about_doc_url_from_documentation_label():
+    """`Documentation` maps to about.doc_url."""
+    dist = _distribution(Documentation="https://demo.readthedocs.io")
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["doc_url"] == "https://demo.readthedocs.io"
+
+
+def test_about_doc_url_from_docs_label():
+    """`Docs` (short form) maps to about.doc_url."""
+    dist = _distribution(Docs="https://demo.readthedocs.io")
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["doc_url"] == "https://demo.readthedocs.io"
+
+
+def test_about_description_truncates_at_first_blank_line():
+    """A multi-paragraph description is truncated to the first paragraph."""
+    description = (
+        "Demo project.\n"
+        "\n"
+        "## Changelog\n"
+        "\n"
+        "- 1.0.0: initial release\n"
+    )
+    dist = FileDistribution(
+        "Metadata-Version: 2.1\n"
+        "Name: demo\n"
+        "Version: 1.0.0\n"
+        "Description: " + description.replace("\n", "\n        ") + "\n"
+    )
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["description"] == "Demo project."
+
+
+def test_about_description_truncates_at_markdown_heading():
+    """A description with an inline Markdown heading stops at the heading."""
+    description = "Demo project.\n# Heading\nMore text.\n"
+    dist = FileDistribution(
+        "Metadata-Version: 2.1\n"
+        "Name: demo\n"
+        "Version: 1.0.0\n"
+        "Description: " + description.replace("\n", "\n        ") + "\n"
+    )
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["description"] == "Demo project."
+
+
+def test_about_description_single_paragraph_unchanged():
+    """A single-paragraph description survives truncation unchanged."""
+    dist = FileDistribution(
+        "Metadata-Version: 2.1\n"
+        "Name: demo\n"
+        "Version: 1.0.0\n"
+        "Description: One line of prose.\n"
+    )
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["description"] == "One line of prose."
+
+
+def test_about_channels_recorded_when_passed():
+    """Channels passed to from_distribution land in about.channels."""
+    dist = _distribution()
+    about = CondaMetadata.from_distribution(
+        dist, channels=("conda-forge", "bioconda")
+    ).about
+    assert about["channels"] == ["conda-forge", "bioconda"]
+
+
+def test_about_channels_omitted_when_empty():
+    """No channels means about.channels is absent (CEP 34 allows it)."""
+    dist = _distribution()
+    about = CondaMetadata.from_distribution(dist).about
+    assert "channels" not in about
+
+
+def test_about_extra_recipe_records_name_version_build():
+    """about.extra.recipe carries name/version/build for provenance."""
+    dist = _distribution()
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["extra"]["recipe"]["name"] == "demo"
+    assert about["extra"]["recipe"]["version"] == "1.0.0"
+    assert about["extra"]["recipe"]["build"] == "pypi_0"
+
+
+def test_about_extra_generator_records_conda_pypi_version():
+    """about.extra.generator records 'conda-pypi' and its version."""
+    import conda_pypi
+
+    dist = _distribution()
+    about = CondaMetadata.from_distribution(dist).about
+    assert about["extra"]["generator"] == "conda-pypi"
+    assert about["extra"]["generator_version"] == conda_pypi.__version__


### PR DESCRIPTION
### Description

Add missing metadata to `about.json`. Addresses issues #343.

### Checklist

- [x] Add a file to the `news` directory 
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation? Not user-facing --> no docs?

