### PR TITLE
Document conda-pypi search beta limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ conda config --set solver rattler
 conda config --append channels conda-pypi
 ```
 
+During the beta, the `conda-pypi` channel might not appear in the
+Anaconda.org web UI and some commands such as `conda search` can fail because
+they request classic `repodata.json` metadata. Use `conda install` or
+`conda create --dry-run` to check whether the solver can use the channel.
+
 After configuring, you can use PyPI packages alongside conda packages in
 your normal conda workflows, without needing to convert PyPI's wheel files
 to conda files.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,6 +48,14 @@ package is selected, conda downloads the artifact directly from PyPI and
 installs it into the environment while tracking it like any other conda
 package.
 
+:::{note}
+During the beta, the `conda-pypi` channel might not appear in the Anaconda.org
+web UI and some commands such as `conda search` can fail because they request
+classic `repodata.json` metadata. This does not necessarily mean the channel is
+down. To test the channel, use `conda install` or `conda create --dry-run` with
+the Rattler solver enabled.
+:::
+
 :::{admonition} Beta
 :class: warning
 The conda-pypi channel is in public beta. It hosts metadata only, for pure Python wheels from PyPI. Compiled wheels are not supported at the moment.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -46,6 +46,36 @@ conda pypi install -n myenv package-name
 
 ## Package Resolution Issues
 
+### `conda search` reports missing `repodata.json`
+
+**Problem**: Checking the `conda-pypi` channel with `conda search` fails.
+
+**Error messages**:
+```
+UnavailableInvalidChannel: HTTP 404 Not Found for channel conda-pypi
+
+Artifact noarch/repodata.json not found
+```
+
+**Cause**: During the beta, the `conda-pypi` channel is served through wheel
+metadata for solver/install workflows. It might not appear in the Anaconda.org
+web UI, and commands such as `conda search` can still request classic
+`repodata.json` metadata. Search support for sharded repodata is tracked in
+[`conda/conda#16134`](https://github.com/conda/conda/issues/16134).
+
+**Solutions**:
+```bash
+# Make sure the supported solver path is enabled
+conda config --set solver rattler
+conda config --append channels conda-pypi
+
+# Test with a dry-run solve instead of conda search
+conda create --dry-run -n conda-pypi-test django-modern-rest
+```
+
+If a dry-run solve or install also fails while using conda 26.5 or newer and
+the Rattler solver, report the full error in the GitHub issue tracker.
+
 ### Package not found on PyPI
 
 **Problem**: Package doesn't exist or has a different name on PyPI.

--- a/news/382-channel-search-troubleshooting
+++ b/news/382-channel-search-troubleshooting
@@ -1,0 +1,5 @@
+### Docs
+
+* Clarify that the `conda-pypi` channel may not appear in the Anaconda.org web UI
+  and that `conda search` can fail during the beta because it requests classic
+  `repodata.json` metadata.


### PR DESCRIPTION
### Description

Clarifies the beta-channel docs for cases where users check `conda-pypi` through the Anaconda.org web UI or `conda search`. During the beta, the channel may not be browseable through the web UI, and `conda search` can fail because it requests classic `repodata.json` metadata. The docs now point users at dry-run solve/install checks with the Rattler solver until sharded-repodata search support lands.

Refs #382.
Refs #373.
Upstream search support is tracked in conda/conda#16134.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] ~Add / update necessary tests?~ Docs-only change; verified with `pixi run -e docs -- sphinx-build -M dirhtml . _build`.
- [x] Add / update outdated documentation?
