### PR TITLE
Refocus pip warning as conda-pypi beta tip

### DIFF
--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -191,8 +191,7 @@ def ensure_target_env_has_externally_managed(command: str):
 
 def notify_externally_managed_future(command: str):
     """
-    Beta-period post-command hook that logs a warning about upcoming
-    EXTERNALLY-MANAGED enforcement instead of placing the marker file.
+    Beta-period post-command hook that points pip users to the conda-pypi beta.
     """
     # Build environments are ephemeral; never show user-facing notices.
     if os.environ.get("CONDA_BUILD_STATE") == "BUILD":
@@ -202,23 +201,17 @@ def notify_externally_managed_future(command: str):
     target_prefix = Path(context.target_prefix)
     if base_prefix == target_prefix or base_prefix.resolve() == target_prefix.resolve():
         return
-    # No point warning about pip protection if pip isn't installed.
+    # No point showing the beta tip if pip isn't installed.
     prefix_data = PrefixData(target_prefix)
     if not list(prefix_data.query("pip")):
         return
 
     if context.plugins.conda_pypi_pip_warning:
-        logger.warning(
+        logger.info(
             "\n"
-            "  This environment has pip installed. A future conda release will\n"
-            "  protect conda environments from accidental 'pip install' usage.\n"
-            "  Try the beta to install PyPI packages natively with conda:\n"
-            "    conda config --set solver rattler\n"
-            "    conda config --append channels conda-pypi\n"
-            "    conda install <package>\n"
-            "  More info: https://docs.conda.io/projects/conda/en/stable/new-features.html"
-            "  To disable this warning, run:"
-            "    conda config --set plugins.conda_pypi_pip_warning false\n"
+            "  Did you know? You can install many PyPI packages with conda\n"
+            "  using the conda-pypi beta. Get started:\n"
+            "    https://docs.conda.io/projects/conda/en/stable/new-features.html\n"
         )
 
 

--- a/conda_pypi/plugin.py
+++ b/conda_pypi/plugin.py
@@ -51,6 +51,6 @@ def conda_package_extractors():
 def conda_settings():
     yield CondaSetting(
         name="conda_pypi_pip_warning",
-        description="Enable or disable the warning about using pip in conda environents",
+        description="Enable or disable the conda-pypi beta tip shown when pip is present",
         parameter=PrimitiveParameter(True),
     )

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -180,11 +180,10 @@ conda pypi install --dry-run niquests pandas
 
 ### Environment protection
 
-`conda-pypi` ships a special file called `EXTERNALLY-MANAGED` that helps
-protect your conda environments from accidental pip usage that could break
-their integrity. This file is automatically installed in the `base`
-environment, all new environments, and existing environments that after running
-a `conda pypi` command on them.
+`conda-pypi` includes support for a special file called `EXTERNALLY-MANAGED`
+that can help protect conda environments from accidental pip usage that could
+break their integrity. During the beta, `conda-pypi` does not automatically add
+this file to conda environments.
 
 More details about this protection mechanism can be found at
 {ref}`externally-managed`.
@@ -196,12 +195,11 @@ More details about this protection mechanism can be found at
 
 #### `conda_pypi_pip_warning`
 
-By default, `conda-pypi` displays a warning when `pip` is detected in a conda
-environment. This warning reminds you that future updates will protect environments
-from using `pip` via the `EXTERNALLY-MANAGED` file defined by
-[PEP 668](https://peps.python.org/pep-0668/).
+By default, `conda-pypi` displays a short beta tip when `pip` is detected in a
+conda environment. The tip points to the conda-pypi beta docs for installing
+PyPI packages with conda.
 
-To disable this warning:
+To disable this tip:
 
 ```bash
 conda config --set plugins.conda_pypi_pip_warning false

--- a/news/385-conda-pypi-beta-tip
+++ b/news/385-conda-pypi-beta-tip
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Refocus the pip warning into a short conda-pypi beta tip. (#385)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -65,7 +65,7 @@ def test_extract_whl_as_conda_pkg(
 
 
 @pytest.mark.parametrize("command", ["install", "create", "env_create"])
-def test_notify_warns_when_pip_installed(
+def test_notify_logs_tip_when_pip_installed(
     mocker: MockerFixture,
     tmp_path: Path,
     command: str,
@@ -80,7 +80,8 @@ def test_notify_warns_when_pip_installed(
 
     notify_externally_managed_future(command)
 
-    mock_logger.warning.assert_called_once()
+    mock_logger.info.assert_called_once()
+    mock_logger.warning.assert_not_called()
 
 
 def test_notify_skips_build_env(
@@ -99,7 +100,7 @@ def test_notify_skips_build_env(
 
     notify_externally_managed_future("install")
 
-    mock_logger.warning.assert_not_called()
+    mock_logger.info.assert_not_called()
 
 
 def test_notify_skips_base_prefix(
@@ -116,7 +117,7 @@ def test_notify_skips_base_prefix(
 
     notify_externally_managed_future("install")
 
-    mock_logger.warning.assert_not_called()
+    mock_logger.info.assert_not_called()
 
 
 def test_notify_skips_no_pip(
@@ -131,14 +132,14 @@ def test_notify_skips_no_pip(
 
     notify_externally_managed_future("install")
 
-    mock_logger.warning.assert_not_called()
+    mock_logger.info.assert_not_called()
 
 
 def test_notify_skips_when_pip_warning_disabled(
     mocker: MockerFixture,
     tmp_path: Path,
 ):
-    """When conda_pypi_pip_warning is False the warning must not be emitted."""
+    """When conda_pypi_pip_warning is False the tip must not be emitted."""
     ctx = mocker.patch("conda_pypi.main.context")
     ctx.conda_prefix = str(tmp_path / "base")
     ctx.target_prefix = str(tmp_path / "env")
@@ -150,7 +151,7 @@ def test_notify_skips_when_pip_warning_disabled(
 
     notify_externally_managed_future("install")
 
-    mock_logger.warning.assert_not_called()
+    mock_logger.info.assert_not_called()
 
 
 def test_pip_warning_setting_defaults_to_true():


### PR DESCRIPTION
### Description

Closes #385.

This implements Dan's suggested reframe from the PR discussion: instead of warning users that future conda releases may take direct `pip install` workflows away, the hook now shows a short conda-pypi beta tip at `INFO` level.

The updated message is:

```text
  Did you know? You can install many PyPI packages with conda
  using the conda-pypi beta. Get started:
    https://docs.conda.io/projects/conda/en/stable/new-features.html
```

This also updates the quickstart so the beta docs no longer say `EXTERNALLY-MANAGED` files are automatically added to conda environments during the beta.

cc @mcg1969 @dashagurova @beckermr

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
