### PR TITLE
Prompt before editable install changes

### DIFF
--- a/conda_pypi/build.py
+++ b/conda_pypi/build.py
@@ -107,6 +107,7 @@ def build_pypa(
     output_path,
     prefix: Path,
     distribution="editable",
+    yes: bool = True,
 ):
     """
     Args:
@@ -124,11 +125,11 @@ def build_pypa(
             try:
                 missing = dependencies.check_dependencies(requirements, prefix=prefix)
                 if missing:
-                    dependencies.ensure_requirements(missing, prefix=prefix)
+                    dependencies.ensure_requirements(missing, prefix=prefix, yes=yes)
                     continue
                 break
             except dependencies.MissingDependencyError as e:
-                dependencies.ensure_requirements(e.dependencies, prefix=prefix)
+                dependencies.ensure_requirements(e.dependencies, prefix=prefix, yes=yes)
 
     build_system_requires = builder.build_system_requires
     log.debug(f"Ensure requirements for build system: {build_system_requires}")
@@ -281,6 +282,7 @@ def pypa_to_conda(
     test_dir: Path | None = None,
     pypi_to_conda_name_mapping: dict | None = None,
     channels: Iterable[str] = (),
+    yes: bool = True,
 ):
     project = Path(project)
 
@@ -294,7 +296,11 @@ def pypa_to_conda(
         tmp_path = Path(tmp_path)
 
         normal_wheel = build_pypa(
-            Path(project), tmp_path, prefix=prefix, distribution=distribution
+            Path(project),
+            tmp_path,
+            prefix=prefix,
+            distribution=distribution,
+            yes=yes,
         )
 
         build_path = tmp_path / "build"

--- a/conda_pypi/cli/install.py
+++ b/conda_pypi/cli/install.py
@@ -1,9 +1,12 @@
 import tempfile
-from argparse import Namespace, _SubParsersAction
+from argparse import SUPPRESS, Namespace, _SubParsersAction
 from pathlib import Path
 
 from conda.auxlib.ish import dals
 from conda.base.context import context
+from conda.cli.common import stdout_json_success
+from conda.cli.conda_argparse import add_output_and_prompt_options
+from conda.exceptions import ArgumentError
 from conda.models.match_spec import MatchSpec
 from packaging.requirements import InvalidRequirement, Requirement
 
@@ -78,6 +81,11 @@ def configure_parser(parser: _SubParsersAction) -> None:
         action="append",
         help="Add a PyPI index URL (can be used multiple times).",
     )
+    output_and_prompt_options = add_output_and_prompt_options(install)
+    # These options also exist on the parent parser. Suppressing subparser
+    # defaults keeps `conda pypi --dry-run install ...` from being overwritten.
+    for action in output_and_prompt_options._group_actions:
+        action.default = SUPPRESS
     install.add_argument(
         "packages",
         metavar="PACKAGE",
@@ -93,7 +101,12 @@ def configure_parser(parser: _SubParsersAction) -> None:
     install.add_argument(
         "-e",
         "--editable",
-        help="Build and install PACKAGE in editable mode using PEP 660.",
+        action="append",
+        metavar="PROJECT_PATH",
+        help=(
+            "Build and install PROJECT_PATH in editable mode using PEP 660. "
+            "Can be used multiple times."
+        ),
     )
 
 
@@ -101,23 +114,56 @@ def execute(args: Namespace) -> int:
     """
     Entry point for the `conda pypi install` subcommand.
     """
-    if not args.editable and not args.packages:
+    editable_projects = args.editable or ()
+    if isinstance(editable_projects, str):
+        editable_projects = (editable_projects,)
+
+    if editable_projects and args.packages:
+        raise ArgumentError(
+            "Cannot combine --editable with package specs. "
+            "Install editable projects and package specs separately."
+        )
+    if not editable_projects and not args.packages:
         raise SystemExit(2)
 
     prefix_path = get_prefix()
+    json_output = context.json
+    yes = bool(args.yes)
 
-    if args.editable:
-        editable_path = Path(args.editable).expanduser()
+    if editable_projects:
+        editable_paths = [Path(project).expanduser() for project in editable_projects]
+        if args.dry_run:
+            if json_output:
+                stdout_json_success(
+                    dry_run=True,
+                    editables=[str(path) for path in editable_paths],
+                    prefix=str(prefix_path),
+                )
+            else:
+                for editable_path in editable_paths:
+                    print(
+                        "Dry run: would build and install editable package "
+                        f"from {editable_path} into {prefix_path}."
+                    )
+            return 0
+
         output_path_manager = tempfile.TemporaryDirectory("conda-pypi")
         with output_path_manager as output_path:
-            package = build.pypa_to_conda(
-                editable_path,
-                distribution="editable",
-                output_path=Path(output_path),
-                prefix=prefix_path,
-                channels=() if args.ignore_channels else tuple(context.channels),
-            )
-            installer.install_ephemeral_conda(prefix_path, package)
+            for editable_path in editable_paths:
+                package = build.pypa_to_conda(
+                    editable_path,
+                    distribution="editable",
+                    output_path=Path(output_path),
+                    prefix=prefix_path,
+                    channels=() if args.ignore_channels else tuple(context.channels),
+                    yes=yes,
+                )
+                installer.install_ephemeral_conda(
+                    prefix_path,
+                    package,
+                    yes=yes,
+                    source=editable_path,
+                )
         return 0
 
     if args.index_urls:
@@ -162,7 +208,7 @@ def execute(args: Namespace) -> int:
         if pkg.channel.canonical_name == channel_url
     ]
 
-    if not context.json:
+    if not json_output:
         if converted_packages:
             converted_packages_dashed = "\n - ".join(converted_packages)
             print(f"Converted packages\n - {converted_packages_dashed}\n")
@@ -174,8 +220,9 @@ def execute(args: Namespace) -> int:
         match_specs,
         channels=[channel_url],
         override_channels=args.ignore_channels,
-        yes=args.yes,
+        yes=yes,
         quiet=args.quiet,
         verbosity=args.verbosity,
         dry_run=args.dry_run,
+        json=json_output,
     )

--- a/conda_pypi/dependencies/pypi.py
+++ b/conda_pypi/dependencies/pypi.py
@@ -61,8 +61,11 @@ def check_dependencies(requirements: Iterable[str], prefix: Path):
     return missing
 
 
-def ensure_requirements(requirements: list[str], prefix: Path):
+def ensure_requirements(requirements: list[str], prefix: Path, yes: bool = True):
     if requirements:
         conda_requirements, _ = requires_to_conda(requirements)
-        # -y may be appropriate during tests only
-        main_subshell("install", "--prefix", str(prefix), "-y", *conda_requirements)
+        command = ["install", "--prefix", str(prefix)]
+        if yes:
+            command.append("--yes")
+        command.extend(conda_requirements)
+        main_subshell(*command)

--- a/conda_pypi/installer.py
+++ b/conda_pypi/installer.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import BinaryIO, Iterable
 from unittest.mock import patch
 
+from conda.cli.install import confirm_yn
 from conda.cli.main import main_subshell
 from conda.core.package_cache_data import PackageCacheData
 from installer import install
@@ -186,7 +187,12 @@ def install_pip(python_executable: str, whl: Path, build_path: Path):
     log.debug(f"Installed to {build_path}")
 
 
-def install_ephemeral_conda(prefix: Path, package: Path):
+def install_ephemeral_conda(
+    prefix: Path,
+    package: Path,
+    yes: bool = True,
+    source: Path | None = None,
+):
     """
     Install [editable] conda package without adding it to the environment's
     package cache, since we don't want to accidentally re-install "a link to a
@@ -200,4 +206,7 @@ def install_ephemeral_conda(prefix: Path, package: Path):
         tempfile.TemporaryDirectory(dir=persistent_pkgs, prefix="ephemeral") as cache_dir,
         patch.dict(os.environ, {"CONDA_PKGS_DIRS": cache_dir}),
     ):
+        if not yes:
+            source_text = source if source is not None else package.name
+            confirm_yn(f"Install editable package from {source_text} into {prefix}")
         main_subshell("install", "--prefix", str(prefix), str(package))

--- a/docs/features.md
+++ b/docs/features.md
@@ -171,7 +171,10 @@ Here are some common usage patterns for editable installations:
 # Install local project in editable mode
 conda pypi install -e ./my-project/
 
-# Multiple local editable packages
+# Preview an editable install without changing the environment
+conda pypi install --dry-run -e ./my-project/
+
+# Install multiple local projects in editable mode
 conda pypi install -e ./package1/ -e ./package2/
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -182,8 +182,11 @@ preparing packages for offline installation.
 # Install local project in editable mode
 conda pypi install -e ./my-project/
 
-# Preview what would be installed
-conda pypi install --dry-run niquests pandas
+# Preview an editable install without changing the environment
+conda pypi install --dry-run -e ./my-project/
+
+# Install multiple local projects in editable mode
+conda pypi install -e ./package1/ -e ./package2/
 ```
 
 ### Environment protection

--- a/news/392-editable-install-prompt
+++ b/news/392-editable-install-prompt
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `--dry-run`, `--yes`, and repeated `--editable` support to editable installs. (#392)

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -6,10 +6,16 @@ from __future__ import annotations
 
 import json
 import re
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from conda.base.context import reset_context
+from conda.exceptions import ArgumentError
 from conda.testing.fixtures import CondaCLIFixture
+
+import conda_pypi.cli.install as install_cli
 
 
 def test_cli(conda_cli):
@@ -21,6 +27,8 @@ def test_cli(conda_cli):
     out, err, rc = conda_cli("pypi", "install", "--help", raises=SystemExit)
     assert rc.value.code == 0  # SystemExit(0) means success
     assert "PyPI packages to install" in out
+    assert "--dry-run" in out
+    assert "--yes" in out
 
     # Test that convert subcommand exists and help works
     out, err, rc = conda_cli("pypi", "convert", "--help", raises=SystemExit)
@@ -39,6 +47,160 @@ def test_cli_plugin():
     assert pypi_subcommand.summary == "Install PyPI packages as conda packages"
     assert pypi_subcommand.action is not None
     assert pypi_subcommand.configure_parser is not None
+
+
+@pytest.fixture
+def editable_args():
+    def factory(project: Path, **overrides) -> Namespace:
+        values = {
+            "editable": [str(project)],
+            "packages": (),
+            "dry_run": False,
+            "yes": False,
+            "ignore_channels": False,
+            "index_urls": None,
+            "quiet": False,
+            "verbosity": 0,
+        }
+        values.update(overrides)
+        return Namespace(**values)
+
+    return factory
+
+
+def test_install_editable_dry_run_reports_each_project(
+    tmp_path, monkeypatch, mocker, capsys, editable_args
+):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    prefix = tmp_path / "prefix"
+    first.mkdir()
+    second.mkdir()
+
+    monkeypatch.setattr(install_cli, "context", SimpleNamespace(json=False, channels=()))
+    monkeypatch.setattr(install_cli, "get_prefix", lambda: prefix)
+    build_editable = mocker.Mock()
+    install_package = mocker.Mock()
+    monkeypatch.setattr(install_cli.build, "pypa_to_conda", build_editable)
+    monkeypatch.setattr(install_cli.installer, "install_ephemeral_conda", install_package)
+
+    assert (
+        install_cli.execute(editable_args(first, editable=[str(first), str(second)], dry_run=True))
+        == 0
+    )
+
+    build_editable.assert_not_called()
+    install_package.assert_not_called()
+    output = capsys.readouterr().out
+    assert f"from {first} into {prefix}" in output
+    assert f"from {second} into {prefix}" in output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("pypi", "install", "--dry-run", "--yes", "-e", "tests/packages/has-build-dep"),
+        ("pypi", "--dry-run", "--yes", "install", "-e", "tests/packages/has-build-dep"),
+    ],
+)
+def test_install_editable_dry_run_accepts_output_options(args, conda_cli: CondaCLIFixture):
+    out, err, rc = conda_cli(*args)
+
+    assert rc == 0, err
+    assert "Dry run: would build and install editable package" in out
+
+
+def test_install_editable_dry_run_accepts_subcommand_json(conda_cli: CondaCLIFixture):
+    out, err, rc = conda_cli(
+        "pypi",
+        "install",
+        "--dry-run",
+        "--json",
+        "-e",
+        "tests/packages/has-build-dep",
+    )
+
+    assert rc == 0, err
+    json_actions = json.loads(out)
+    assert json_actions["success"]
+    assert json_actions["dry_run"]
+    assert json_actions["editables"] == ["tests/packages/has-build-dep"]
+
+
+def test_install_editable_rejects_package_specs(tmp_path, editable_args):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(ArgumentError, match="Cannot combine --editable"):
+        install_cli.execute(editable_args(project, packages=("requests",)))
+
+
+@pytest.mark.parametrize("yes", [False, True])
+def test_install_editable_passes_prompt_state_to_mutating_steps(
+    yes, tmp_path, monkeypatch, mocker, editable_args
+):
+    project = tmp_path / "project"
+    prefix = tmp_path / "prefix"
+    package = tmp_path / "editable.conda"
+    project.mkdir()
+
+    monkeypatch.setattr(install_cli, "get_prefix", lambda: prefix)
+    monkeypatch.setattr(install_cli, "context", SimpleNamespace(json=False, channels=()))
+    build_editable = mocker.Mock(return_value=package)
+    install_package = mocker.Mock()
+    monkeypatch.setattr(install_cli.build, "pypa_to_conda", build_editable)
+    monkeypatch.setattr(install_cli.installer, "install_ephemeral_conda", install_package)
+
+    assert install_cli.execute(editable_args(project, yes=yes)) == 0
+
+    build_editable.assert_called_once()
+    assert build_editable.call_args.kwargs["yes"] is yes
+    install_package.assert_called_once_with(prefix, package, yes=yes, source=project)
+
+
+def test_install_editable_installs_multiple_projects_in_order(
+    tmp_path, monkeypatch, mocker, editable_args
+):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    prefix = tmp_path / "prefix"
+    first_package = tmp_path / "first.conda"
+    second_package = tmp_path / "second.conda"
+    first.mkdir()
+    second.mkdir()
+
+    monkeypatch.setattr(install_cli, "get_prefix", lambda: prefix)
+    monkeypatch.setattr(install_cli, "context", SimpleNamespace(json=False, channels=()))
+    build_editable = mocker.Mock(side_effect=[first_package, second_package])
+    install_package = mocker.Mock()
+    monkeypatch.setattr(install_cli.build, "pypa_to_conda", build_editable)
+    monkeypatch.setattr(install_cli.installer, "install_ephemeral_conda", install_package)
+    calls = mocker.Mock()
+    calls.attach_mock(build_editable, "build")
+    calls.attach_mock(install_package, "install")
+
+    assert install_cli.execute(editable_args(first, editable=[str(first), str(second)])) == 0
+
+    assert calls.mock_calls == [
+        mocker.call.build(
+            first,
+            distribution="editable",
+            output_path=mocker.ANY,
+            prefix=prefix,
+            channels=(),
+            yes=False,
+        ),
+        mocker.call.install(prefix, first_package, yes=False, source=first),
+        mocker.call.build(
+            second,
+            distribution="editable",
+            output_path=mocker.ANY,
+            prefix=prefix,
+            channels=(),
+            yes=False,
+        ),
+        mocker.call.install(prefix, second_package, yes=False, source=second),
+    ]
 
 
 def test_index_urls(tmp_env, conda_cli, pypi_local_index):
@@ -108,7 +270,7 @@ def test_install_requires_package_without_editable(conda_cli: CondaCLIFixture):
 
 def test_install_editable_without_packages_succeeds(conda_cli: CondaCLIFixture):
     project = "tests/packages/has-build-dep"
-    out, err, rc = conda_cli("pypi", "install", "-e", project)
+    out, err, rc = conda_cli("pypi", "--yes", "install", "-e", project)
     assert rc == 0
 
 

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -124,7 +124,7 @@ def test_install_editable_dry_run_accepts_subcommand_json(conda_cli: CondaCLIFix
     json_actions = json.loads(out)
     assert json_actions["success"]
     assert json_actions["dry_run"]
-    assert json_actions["editables"] == ["tests/packages/has-build-dep"]
+    assert json_actions["editables"] == [str(Path("tests/packages/has-build-dep"))]
 
 
 def test_install_editable_rejects_package_specs(tmp_path, editable_args):

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -102,6 +102,8 @@ def test_ensure_requirements_prompt_state(yes, expected_command, monkeypatch, mo
 )
 def test_install_ephemeral_conda_prompt_state(yes, source, monkeypatch, mocker, tmp_path):
     cache = SimpleNamespace(pkgs_dir=tmp_path)
+    prefix = Path("/prefix")
+    package = Path("/tmp/editable.conda")
 
     confirm = mocker.Mock()
     install = mocker.Mock()
@@ -117,20 +119,18 @@ def test_install_ephemeral_conda_prompt_state(yes, source, monkeypatch, mocker, 
     monkeypatch.setattr(installer, "main_subshell", install)
 
     installer.install_ephemeral_conda(
-        Path("/prefix"),
-        Path("/tmp/editable.conda"),
+        prefix,
+        package,
         yes=yes,
         source=source,
     )
 
     if yes:
-        expected_calls = [
-            mocker.call.install("install", "--prefix", "/prefix", "/tmp/editable.conda")
-        ]
+        expected_calls = [mocker.call.install("install", "--prefix", str(prefix), str(package))]
     else:
         expected_calls = [
-            mocker.call.confirm("Install editable package from /src/project into /prefix"),
-            mocker.call.install("install", "--prefix", "/prefix", "/tmp/editable.conda"),
+            mocker.call.confirm(f"Install editable package from {source} into {prefix}"),
+            mocker.call.install("install", "--prefix", str(prefix), str(package)),
         ]
     assert calls.mock_calls == expected_calls
 

--- a/tests/test_editable.py
+++ b/tests/test_editable.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import build
 import pytest
@@ -9,7 +10,9 @@ from conda.cli.main import main_subshell
 from conda.core.prefix_data import PrefixData
 from packaging.requirements import InvalidRequirement
 
+import conda_pypi.dependencies.pypi as pypi_dependencies
 import conda_pypi.dependencies_subprocess
+from conda_pypi import installer
 from conda_pypi.build import filter, pypa_to_conda
 from conda_pypi.dependencies.pypi import check_dependencies, ensure_requirements
 
@@ -75,11 +78,61 @@ def test_build_wheel(package, package_path, tmp_path):
             pytest.xfail(reason=str(e))
 
 
-def test_ensure_requirements(mocker):
-    mock = mocker.patch("conda_pypi.dependencies.pypi.main_subshell")
-    ensure_requirements(["flit_core"], prefix=Path())
+@pytest.mark.parametrize(
+    ("yes", "expected_command"),
+    [
+        (True, ("install", "--prefix", ".", "--yes", "flit-core")),
+        (False, ("install", "--prefix", ".", "flit-core")),
+    ],
+)
+def test_ensure_requirements_prompt_state(yes, expected_command, monkeypatch, mocker):
+    mock = mocker.Mock()
+    monkeypatch.setattr(pypi_dependencies, "main_subshell", mock)
+    ensure_requirements(["flit_core"], prefix=Path(), yes=yes)
     # normalizes/converts the underscore flit_core->flit-core
-    assert mock.call_args.args == ("install", "--prefix", ".", "-y", "flit-core")
+    assert mock.call_args.args == expected_command
+
+
+@pytest.mark.parametrize(
+    ("yes", "source"),
+    [
+        (False, Path("/src/project")),
+        (True, None),
+    ],
+)
+def test_install_ephemeral_conda_prompt_state(yes, source, monkeypatch, mocker, tmp_path):
+    cache = SimpleNamespace(pkgs_dir=tmp_path)
+
+    confirm = mocker.Mock()
+    install = mocker.Mock()
+    calls = mocker.Mock()
+    calls.attach_mock(confirm, "confirm")
+    calls.attach_mock(install, "install")
+    monkeypatch.setattr(
+        installer.PackageCacheData,
+        "first_writable",
+        staticmethod(lambda: cache),
+    )
+    monkeypatch.setattr(installer, "confirm_yn", confirm)
+    monkeypatch.setattr(installer, "main_subshell", install)
+
+    installer.install_ephemeral_conda(
+        Path("/prefix"),
+        Path("/tmp/editable.conda"),
+        yes=yes,
+        source=source,
+    )
+
+    if yes:
+        expected_calls = [
+            mocker.call.install("install", "--prefix", "/prefix", "/tmp/editable.conda")
+        ]
+    else:
+        expected_calls = [
+            mocker.call.confirm("Install editable package from /src/project into /prefix"),
+            mocker.call.install("install", "--prefix", "/prefix", "/tmp/editable.conda"),
+        ]
+    assert calls.mock_calls == expected_calls
 
 
 def test_check_dependencies_flattens_missing_dependencies(mocker):
@@ -123,6 +176,7 @@ def test_build_in_env(tmp_path):
     main_subshell(
         "pypi",
         "install",
+        "--yes",
         "--prefix",
         prefix,
         "-e",


### PR DESCRIPTION
### Description

Fixes #392.

`conda pypi install -e .` could change the target environment without giving the user the normal yes/no gate. This makes editable installs follow the same prompt controls as the rest of `conda pypi install`.

This PR:

- adds editable `--dry-run` support, including JSON output
- passes `--yes` through build-requirement installs and the final editable package install
- prompts before the ephemeral editable conda package is installed when `--yes` is not set
- supports repeated `-e` / `--editable` for installing multiple local projects in order
- keeps editable project paths and normal package specs separate for now
- updates the editable-install docs and release note

Validation:

- `pixi run --environment test-py313 python -m pytest -q`
- `pixi run --environment lint ruff check .`
- `pixi run --environment lint ruff format --check conda_pypi/cli/install.py conda_pypi/build.py conda_pypi/dependencies/pypi.py conda_pypi/installer.py tests/cli/test_install.py tests/test_editable.py`

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
