### PR TITLE
CondaFileIOError takes a `filepath` and `message` as arguments

### DIFF
--- a/conda_pypi/post_command/install.py
+++ b/conda_pypi/post_command/install.py
@@ -120,5 +120,5 @@ def _pypi_lines_from_paths(paths: Iterable[str] | None = None) -> list[str]:
                     if line.startswith(line_prefix):
                         lines.append(line[len(line_prefix) :])
         except OSError as exc:
-            raise CondaFileIOError(f"Could not process {path}") from exc
+            raise CondaFileIOError(filepath=path, message="Could not process file") from exc
     return lines


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
