### PR TITLE
Derive wheel build string for index.json from WHEEL metadata

### DIFF
--- a/conda_pypi/package_extractors/whl.py
+++ b/conda_pypi/package_extractors/whl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from email.parser import HeaderParser
 from logging import getLogger

--- a/conda_pypi/package_extractors/whl.py
+++ b/conda_pypi/package_extractors/whl.py
@@ -5,7 +5,7 @@ from email.parser import HeaderParser
 from logging import getLogger
 from os import PathLike
 from pathlib import Path
-from typing import BinaryIO, Iterable, Literal, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, BinaryIO, Iterable, Literal, Tuple
 
 import installer.utils
 from installer.destinations import WheelDestination
@@ -31,6 +31,7 @@ SCHEME_TO_CONDA_PREFIX: dict[Scheme, str] = {
 
 if TYPE_CHECKING:
     from email.message import Message
+
 
 def _create_build_string_from_wheel_meta_and_filename(
     wheel_meta: Message,
@@ -66,6 +67,7 @@ def _create_build_string_from_wheel_meta_and_filename(
 
     build_string = f"{wheel_tag.replace('-', '_')}_{build_number}"
     return build_string, build_number
+
 
 # inline version of
 # from conda.gateways.disk.create import write_as_json_to_file
@@ -174,7 +176,9 @@ class MyWheelDestination(WheelDestination):
 
         wheel_meta = HeaderParser().parsestr(source.read_dist_info("WHEEL"))
 
-        build_string, build_number = _create_build_string_from_wheel_meta_and_filename(wheel_meta, wheel_filename)
+        build_string, build_number = _create_build_string_from_wheel_meta_and_filename(
+            wheel_meta, wheel_filename
+        )
 
         index_json_data = {
             "name": package_name,

--- a/conda_pypi/package_extractors/whl.py
+++ b/conda_pypi/package_extractors/whl.py
@@ -36,8 +36,14 @@ def write_as_json_to_file(file_path, obj):
 
 
 class MyWheelDestination(WheelDestination):
-    def __init__(self, target_full_path: str | Path, source: WheelFile):
+    def __init__(
+        self,
+        target_full_path: str | Path,
+        source: WheelFile,
+        whl_full_path: str | Path,
+    ):
         self.target_full_path = Path(target_full_path)
+        self.whl_full_path = Path(whl_full_path)
         self.sp_dir = self.target_full_path / "site-packages"
         self.entry_points = []
         self.source = source
@@ -122,10 +128,10 @@ class MyWheelDestination(WheelDestination):
         }
         write_as_json_to_file(info_dir / "paths.json", paths_json_data)
 
-        # index.json — fn from zip path; Tag and Build from WHEEL dist-info.
+        # index.json — fn from wheel path; Tag and Build from WHEEL dist-info.
         package_name = str(source.distribution)
         package_version = str(source.version)
-        wheel_filename = Path(source._zipfile.filename).name
+        wheel_filename = self.whl_full_path.name
 
         wheel_meta = HeaderParser().parsestr(source.read_dist_info("WHEEL"))
         tag_lines = wheel_meta.get_all("Tag") or []
@@ -191,9 +197,10 @@ class MyWheelDestination(WheelDestination):
 
 
 def extract_whl_as_conda_pkg(whl_full_path: str | Path, target_full_path: str | Path):
+    whl_full_path = Path(whl_full_path)
     with WheelFile.open(whl_full_path) as source:
         installer.install(
             source=source,
-            destination=MyWheelDestination(target_full_path, source),
+            destination=MyWheelDestination(target_full_path, source, whl_full_path),
             additional_metadata={"INSTALLER": b"conda-via-whl"},
         )

--- a/conda_pypi/package_extractors/whl.py
+++ b/conda_pypi/package_extractors/whl.py
@@ -1,5 +1,6 @@
 import json
 from email.parser import HeaderParser
+from logging import getLogger
 from os import PathLike
 from pathlib import Path
 from typing import BinaryIO, Iterable, Literal, Tuple
@@ -13,6 +14,8 @@ from packaging.tags import parse_tag
 
 from conda_pypi.license_files import copy_into_info_licenses, package_metadata_from_metadata_body
 from conda_pypi.utils import sha256_base64url_to_hex
+
+logger = getLogger(__name__)
 
 # Maps wheel scheme names to their conda package directory prefix.
 # An empty string means files go directly under the package root (env prefix).
@@ -126,8 +129,7 @@ class MyWheelDestination(WheelDestination):
 
         wheel_meta = HeaderParser().parsestr(source.read_dist_info("WHEEL"))
         tag_lines = wheel_meta.get_all("Tag") or []
-        # WHEEL lists expanded tags; filenames may compress (py2.py3-none-any). Expand via
-        # parse_tag when needed and prefer py3-none-any to match repodata v3.
+        # WHEEL lists expanded tags; filenames may compress (py2.py3-none-any).
         if tag_lines:
             tag_candidates = tag_lines
         else:
@@ -135,6 +137,14 @@ class MyWheelDestination(WheelDestination):
             tag_candidates = [str(t) for t in parse_tag(parse_wheel_filename(wheel_filename).tag)]
         # Prefer py3-none-any to match repodata v3.
         wheel_tag = "py3-none-any" if "py3-none-any" in tag_candidates else max(tag_candidates)
+        # Normalize noarch tags to py3-none-any to match repodata v3.
+        if wheel_tag != "py3-none-any" and wheel_tag.endswith("-none-any"):
+            logger.info(
+                "Normalizing wheel tag %s to py3-none-any for index.json build "
+                "(matches repodata v3 noarch convention)",
+                wheel_tag,
+            )
+            wheel_tag = "py3-none-any"
 
         build_number = 0
         wheel_build = wheel_meta.get("Build")

--- a/conda_pypi/package_extractors/whl.py
+++ b/conda_pypi/package_extractors/whl.py
@@ -3,7 +3,7 @@ from email.parser import HeaderParser
 from logging import getLogger
 from os import PathLike
 from pathlib import Path
-from typing import BinaryIO, Iterable, Literal, Tuple
+from typing import BinaryIO, Iterable, Literal, Tuple, TYPE_CHECKING
 
 import installer.utils
 from installer.destinations import WheelDestination
@@ -27,6 +27,43 @@ SCHEME_TO_CONDA_PREFIX: dict[Scheme, str] = {
     "headers": "include",
 }
 
+if TYPE_CHECKING:
+    from email.message import Message
+
+def _create_build_string_from_wheel_meta_and_filename(
+    wheel_meta: Message,
+    wheel_filename: str,
+) -> tuple[str, int]:
+    """Create a build string and number from wheel metadata and filename.
+
+    Wheel metadata (the WHEEL file) is the primary source and filename is secondary.
+    Some normalization is applied for compatibility with repodata v3.
+    """
+    tag_lines = wheel_meta.get_all("Tag") or []
+    # WHEEL lists expanded tags; filenames may compress (py2.py3-none-any).
+    if tag_lines:
+        tag_candidates = tag_lines
+    else:
+        # parse_tag will expand the compressed tag format (py2.py3-none-any) to a list of tags.
+        tag_candidates = [str(t) for t in parse_tag(parse_wheel_filename(wheel_filename).tag)]
+    # Prefer py3-none-any to match repodata v3.
+    wheel_tag = "py3-none-any" if "py3-none-any" in tag_candidates else max(tag_candidates)
+    # Normalize noarch tags to py3-none-any to match repodata v3.
+    if wheel_tag != "py3-none-any" and wheel_tag.endswith("-none-any"):
+        logger.info(
+            "Normalizing wheel tag %s to py3-none-any for index.json build "
+            "(matches repodata v3 noarch convention)",
+            wheel_tag,
+        )
+        wheel_tag = "py3-none-any"
+
+    build_number = 0
+    wheel_build = wheel_meta.get("Build")
+    if wheel_build is not None and wheel_build.isdigit():
+        build_number = int(wheel_build)
+
+    build_string = f"{wheel_tag.replace('-', '_')}_{build_number}"
+    return build_string, build_number
 
 # inline version of
 # from conda.gateways.disk.create import write_as_json_to_file
@@ -134,30 +171,8 @@ class MyWheelDestination(WheelDestination):
         wheel_filename = self.whl_full_path.name
 
         wheel_meta = HeaderParser().parsestr(source.read_dist_info("WHEEL"))
-        tag_lines = wheel_meta.get_all("Tag") or []
-        # WHEEL lists expanded tags; filenames may compress (py2.py3-none-any).
-        if tag_lines:
-            tag_candidates = tag_lines
-        else:
-            # parse_tag will expand the compressed tag format (py2.py3-none-any) to a list of tags.
-            tag_candidates = [str(t) for t in parse_tag(parse_wheel_filename(wheel_filename).tag)]
-        # Prefer py3-none-any to match repodata v3.
-        wheel_tag = "py3-none-any" if "py3-none-any" in tag_candidates else max(tag_candidates)
-        # Normalize noarch tags to py3-none-any to match repodata v3.
-        if wheel_tag != "py3-none-any" and wheel_tag.endswith("-none-any"):
-            logger.info(
-                "Normalizing wheel tag %s to py3-none-any for index.json build "
-                "(matches repodata v3 noarch convention)",
-                wheel_tag,
-            )
-            wheel_tag = "py3-none-any"
 
-        build_number = 0
-        wheel_build = wheel_meta.get("Build")
-        if wheel_build is not None and wheel_build.isdigit():
-            build_number = int(wheel_build)
-
-        build_string = f"{wheel_tag.replace('-', '_')}_{build_number}"
+        build_string, build_number = _create_build_string_from_wheel_meta_and_filename(wheel_meta, wheel_filename)
 
         index_json_data = {
             "name": package_name,

--- a/conda_pypi/package_extractors/whl.py
+++ b/conda_pypi/package_extractors/whl.py
@@ -134,7 +134,7 @@ class MyWheelDestination(WheelDestination):
             # parse_tag will expand the compressed tag format (py2.py3-none-any) to a list of tags.
             tag_candidates = [str(t) for t in parse_tag(parse_wheel_filename(wheel_filename).tag)]
         # Prefer py3-none-any to match repodata v3.
-        wheel_tag = next((t for t in tag_candidates if t == "py3-none-any"), tag_candidates[0])
+        wheel_tag = "py3-none-any" if "py3-none-any" in tag_candidates else max(tag_candidates)
 
         build_number = 0
         wheel_build = wheel_meta.get("Build")

--- a/conda_pypi/package_extractors/whl.py
+++ b/conda_pypi/package_extractors/whl.py
@@ -1,4 +1,5 @@
 import json
+from email.parser import HeaderParser
 from os import PathLike
 from pathlib import Path
 from typing import BinaryIO, Iterable, Literal, Tuple
@@ -7,7 +8,8 @@ import installer.utils
 from installer.destinations import WheelDestination
 from installer.records import Hash, RecordEntry
 from installer.sources import WheelFile
-from installer.utils import Scheme
+from installer.utils import Scheme, parse_wheel_filename
+from packaging.tags import parse_tag
 
 from conda_pypi.license_files import copy_into_info_licenses, package_metadata_from_metadata_body
 from conda_pypi.utils import sha256_base64url_to_hex
@@ -117,21 +119,36 @@ class MyWheelDestination(WheelDestination):
         }
         write_as_json_to_file(info_dir / "paths.json", paths_json_data)
 
-        # index.json
-        # Set fn to include the build string AND extension so _get_json_fn() works correctly
-        # Format: name-version-build.whl (e.g., "requests-2.28.0-pypi_0.whl")
-        # The extension is required because _get_json_fn() uses endswith() to detect package type
+        # index.json — fn from zip path; Tag and Build from WHEEL dist-info.
         package_name = str(source.distribution)
         package_version = str(source.version)
-        build_string = "pypi_0"
-        fn = f"{package_name}-{package_version}-{build_string}.whl"
+        wheel_filename = Path(source._zipfile.filename).name
+
+        wheel_meta = HeaderParser().parsestr(source.read_dist_info("WHEEL"))
+        tag_lines = wheel_meta.get_all("Tag") or []
+        # WHEEL lists expanded tags; filenames may compress (py2.py3-none-any). Expand via
+        # parse_tag when needed and prefer py3-none-any to match repodata v3.
+        if tag_lines:
+            tag_candidates = tag_lines
+        else:
+            # parse_tag will expand the compressed tag format (py2.py3-none-any) to a list of tags.
+            tag_candidates = [str(t) for t in parse_tag(parse_wheel_filename(wheel_filename).tag)]
+        # Prefer py3-none-any to match repodata v3.
+        wheel_tag = next((t for t in tag_candidates if t == "py3-none-any"), tag_candidates[0])
+
+        build_number = 0
+        wheel_build = wheel_meta.get("Build")
+        if wheel_build is not None and wheel_build.isdigit():
+            build_number = int(wheel_build)
+
+        build_string = f"{wheel_tag.replace('-', '_')}_{build_number}"
 
         index_json_data = {
             "name": package_name,
             "version": package_version,
             "build": build_string,
-            "build_number": 0,
-            "fn": fn,
+            "build_number": build_number,
+            "fn": wheel_filename,
         }
         write_as_json_to_file(info_dir / "index.json", index_json_data)
 

--- a/docs/developer/marker-conversion.md
+++ b/docs/developer/marker-conversion.md
@@ -54,7 +54,7 @@ Omissions are mostly intentional, for example virtual-package coverage is bounde
 | {py:mod}`conda_pypi.markers` | Marker AST walk and clause normalization. |
 | {py:func}`conda_pypi.markers.extract_marker_condition_and_extras` | Splits a {py:class}`packaging.markers.Marker` into a condition string and `extra` names. |
 | {py:func}`conda_pypi.pypi_metadata.pypi_to_repodata` | `v3.whl` repodata from PyPI JSON. Names use {py:func}`conda_pypi.name_mapping.pypi_to_conda_name`. |
-| {py:func}`conda_pypi.package_extractors.whl.extract_whl_as_conda_pkg` | Direct `.whl` install: `info/index.json` `fn` is the wheel basename on disk; `build` comes from WHEEL `Tag` / `Build` (see {ref}`wheel-installed-metadata`). |
+| {py:func}`conda_pypi.package_extractors.whl.extract_whl_as_conda_pkg` | Direct `.whl` install: `info/index.json` `fn` is the wheel basename on disk; `build` from WHEEL tags with noarch normalization to `py3_none_any_0` (see {ref}`wheel-installed-metadata`). |
 | {py:func}`conda_pypi.translate.requires_to_conda` | `depends` / `extras` when building `.conda` packages from wheel `METADATA` (no `[when="…"]` on depends, extras-only marker routing). |
 
 ## MatchSpec and `[when="…"]`

--- a/docs/developer/marker-conversion.md
+++ b/docs/developer/marker-conversion.md
@@ -54,6 +54,7 @@ Omissions are mostly intentional, for example virtual-package coverage is bounde
 | {py:mod}`conda_pypi.markers` | Marker AST walk and clause normalization. |
 | {py:func}`conda_pypi.markers.extract_marker_condition_and_extras` | Splits a {py:class}`packaging.markers.Marker` into a condition string and `extra` names. |
 | {py:func}`conda_pypi.pypi_metadata.pypi_to_repodata` | `v3.whl` repodata from PyPI JSON. Names use {py:func}`conda_pypi.name_mapping.pypi_to_conda_name`. |
+| {py:func}`conda_pypi.package_extractors.whl.extract_whl_as_conda_pkg` | Direct `.whl` install: `info/index.json` `fn` is the wheel basename on disk; `build` comes from WHEEL `Tag` / `Build` (see {ref}`wheel-installed-metadata`). |
 | {py:func}`conda_pypi.translate.requires_to_conda` | `depends` / `extras` when building `.conda` packages from wheel `METADATA` (no `[when="…"]` on depends, extras-only marker routing). |
 
 ## MatchSpec and `[when="…"]`

--- a/docs/features.md
+++ b/docs/features.md
@@ -151,6 +151,23 @@ conda install -c https://my-wheel-channel requests
 
 Wheels served this way behave like any other conda package.
 
+(wheel-installed-metadata)=
+
+#### Installed package metadata
+
+When a wheel is installed directly (from a wheel channel or a `.whl` file),
+conda-pypi writes `info/index.json` with:
+
+- `fn` — the wheel basename on disk (the PyPI upload filename), for example
+  `requests-2.32.5-py3-none-any.whl`
+- `build` — derived from the WHEEL dist-info `Tag` and `Build` headers, for
+  example `py3_none_any_0`
+
+These fields mirror repodata v3 channel records. They intentionally differ:
+`fn` identifies the wheel artifact, while `build` is the conda build string.
+Lockfile restore and `conda-meta` JSON filenames use `name`, `version`, and
+`build`, not `fn`.
+
 #### Extras and markers
 
 Wheels in a channel can declare [dependency specifier extras](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras)

--- a/docs/features.md
+++ b/docs/features.md
@@ -160,8 +160,9 @@ conda-pypi writes `info/index.json` with:
 
 - `fn` — the wheel basename on disk (the PyPI upload filename), for example
   `requests-2.32.5-py3-none-any.whl`
-- `build` — derived from the WHEEL dist-info `Tag` and `Build` headers, for
-  example `py3_none_any_0`
+- `build` — from WHEEL `Tag` / `Build` headers (prefer `py3-none-any`, else highest
+  tag). Noarch tags other than `py3-none-any` are normalized to `py3_none_any_0` to
+  match repodata v3, with an informational log when that happens.
 
 These fields mirror repodata v3 channel records. They intentionally differ:
 `fn` identifies the wheel artifact, while `build` is the conda build string.

--- a/news/420-wheel-index-json-metadata
+++ b/news/420-wheel-index-json-metadata
@@ -1,0 +1,7 @@
+### Bug fixes
+
+* Fix direct `.whl` install `info/index.json` metadata: `fn` is the wheel basename on disk and `build` is derived from WHEEL `Tag` / `Build` headers (preferring `py3-none-any`), matching repodata v3 and fixing lockfile restore mismatches. (#417 via #420)
+
+### Docs
+
+* Document installed wheel `index.json` `fn` and `build` fields in the wheel channels guide. (#420)

--- a/news/420-wheel-index-json-metadata
+++ b/news/420-wheel-index-json-metadata
@@ -1,6 +1,6 @@
 ### Bug fixes
 
-* Fix direct `.whl` install `info/index.json` metadata: `fn` is the wheel basename on disk and `build` is derived from WHEEL `Tag` / `Build` headers (preferring `py3-none-any`), matching repodata v3 and fixing lockfile restore mismatches. (#417 via #420)
+* Fix direct `.whl` install `info/index.json` metadata: `fn` is the wheel basename on disk and `build` is derived from WHEEL tags (normalizing noarch tags to `py3_none_any_0` to match repodata v3), fixing lockfile restore mismatches. (#417 via #420)
 
 ### Docs
 

--- a/tests/test_conda_meta_json_filename.py
+++ b/tests/test_conda_meta_json_filename.py
@@ -9,80 +9,81 @@ field repodata v3 uses (PyPI upload filename).
 from __future__ import annotations
 
 import json
-import zipfile
+from email.parser import HeaderParser
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
-from conda_pypi.package_extractors.whl import extract_whl_as_conda_pkg
+from conda_pypi.package_extractors.whl import (
+    _create_build_string_from_wheel_meta_and_filename,
+    extract_whl_as_conda_pkg,
+)
 
+if TYPE_CHECKING:
+    from email.message import Message
 
-def _make_wheel(
-    path: Path,
-    name: str,
-    version: str,
-    tags: list[str],
-    filename_tag: str | None = None,
+def _make_wheel_meta(
+    tags: list[str] | None = None,
     wheel_build: str | None = None,
-) -> Path:
-    """Minimal installable wheel for extract_whl_as_conda_pkg (Tag/Build/RECORD/pkg).
-
-    Separate from tests/cli/test_index.py make_wheel, which targets indexing only.
-    """
-    if filename_tag is None:
-        filename_tag = "py3-none-any" if "py3-none-any" in tags else tags[0]
-    wheel_path = path / f"{name}-{version}-{filename_tag}.whl"
-    dist_info = f"{name}-{version}.dist-info"
-    wheel_lines = ["Wheel-Version: 1.0\nGenerator: test\n"]
-    for tag in tags:
-        wheel_lines.append(f"Tag: {tag}\n")
+) -> Message:
+    """Parsed WHEEL dist-info headers, as from HeaderParser on a WHEEL file."""
+    lines = ["Wheel-Version: 1.0\n", "Generator: test\n"]
+    if tags:
+        for tag in tags:
+            lines.append(f"Tag: {tag}\n")
     if wheel_build is not None:
-        wheel_lines.append(f"Build: {wheel_build}\n")
-    metadata = "\n".join(
-        [
-            "Metadata-Version: 2.1",
-            f"Name: {name}",
-            f"Version: {version}",
-        ]
-    )
-    with zipfile.ZipFile(wheel_path, "w") as zf:
-        zf.writestr("pkg.py", "# pkg\n")
-        zf.writestr(f"{dist_info}/METADATA", metadata)
-        zf.writestr(f"{dist_info}/WHEEL", "".join(wheel_lines))
-        zf.writestr(f"{dist_info}/top_level.txt", "pkg\n")
-        zf.writestr(f"{dist_info}/RECORD", "pkg.py,,\n")
-    return wheel_path
+        lines.append(f"Build: {wheel_build}\n")
+    return HeaderParser().parsestr("".join(lines))
 
 
 @pytest.mark.parametrize(
     ("tags", "wheel_build", "expected_build"),
     [
-        (["py2-none-any"], None, "py3_none_any_0"),
+        (["py310-none-any", "py3-none-any"], None, "py3_none_any_0"),
         (["py38-none-any"], None, "py3_none_any_0"),
         (["py2-none-any", "py3-none-any"], None, "py3_none_any_0"),
         (["py3-none-any"], "1", "py3_none_any_1"),
         (["cp312-cp312-win_amd64"], None, "cp312_cp312_win_amd64_0"),
     ],
 )
-def test_extract_whl_index_json_build_from_wheel_metadata(
-    tmp_path: Path,
+def test_create_build_string_from_wheel_meta_and_filename_(
     tags: list[str],
     wheel_build: str | None,
     expected_build: str,
 ):
-    name = "test_pkg"
-    version = "1.0.0"
-    wheel_path = _make_wheel(tmp_path, name, version, tags, wheel_build=wheel_build)
-    extract_dir = tmp_path / "extract"
-    extract_whl_as_conda_pkg(wheel_path, extract_dir)
+    wheel_meta = _make_wheel_meta(tags, wheel_build)
+    last_tag = wheel_meta.get_all("Tag")[-1]
+    wheel_filename = f"test_pkg-1.0.0-{last_tag}.whl"
 
-    index_data = json.loads((extract_dir / "info" / "index.json").read_text())
+    build_string, build_number = _create_build_string_from_wheel_meta_and_filename(
+        wheel_meta, wheel_filename
+    )
+
     expected_build_number = int(wheel_build) if wheel_build is not None else 0
-    assert index_data["name"] == name
-    assert index_data["version"] == version
-    assert index_data["fn"] == wheel_path.name
-    assert index_data["build"] == expected_build
-    assert index_data["build_number"] == expected_build_number
+    assert build_string == expected_build
+    assert build_number == expected_build_number
+
+
+@pytest.mark.parametrize(("filename", "expected_build"), [
+    ("test_pkg-1.0.0-py3-none-any.whl", "py3_none_any_0"),
+    ("test_pkg-1.0.0-py38-none-any.whl", "py3_none_any_0"),
+    ("test_pkg-1.0.0-py2-none-any.whl", "py3_none_any_0"),
+    ("test_pkg-1.0.0-py2.py3-none-any.whl", "py3_none_any_0"),
+    ("test_pkg-1.0.0-cp312-cp312-win_amd64.whl", "cp312_cp312_win_amd64_0"),
+])
+def test_create_build_string_from_wheel_meta_and_filename_filename_fallback(
+    filename: str,
+    expected_build: str,
+):
+    # No Tag headers — build string comes from the wheel filename tag segment.
+    wheel_meta = _make_wheel_meta()
+    build_string, build_number = _create_build_string_from_wheel_meta_and_filename(
+        wheel_meta, filename
+    )
+    assert build_string == expected_build
+    assert build_number == 0
+
 
 
 def test_extract_whl_sets_fn_correctly(

--- a/tests/test_conda_meta_json_filename.py
+++ b/tests/test_conda_meta_json_filename.py
@@ -1,6 +1,9 @@
 """
-Test that wheel files installed via conda-pypi create JSON files in conda-meta/
-with the correct filename format: name-version-build.json
+Test index.json written by direct .whl extraction (extract_whl_as_conda_pkg).
+
+conda-meta/*.json filenames use name-version-build (conda derives build from
+index.json, not fn). index.json fn is the wheel basename on disk — the same
+field repodata v3 uses (PyPI upload filename).
 """
 
 from __future__ import annotations
@@ -8,14 +11,19 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from installer.sources import WheelFile
+
 
 def test_extract_whl_sets_fn_correctly(
     pypi_demo_package_wheel_path: Path,
     tmp_path: Path,
 ):
     """
-    Test that extract_whl_as_conda_pkg sets the fn field correctly in index.json.
-    This is a unit test that directly tests the metadata creation.
+    extract_whl_as_conda_pkg must write index.json that matches repodata v3 channel records.
+
+    fn is the wheel basename on disk; build is tag-derived with underscores. These fields
+    are not interchangeable — lockfile restore reads index.json directly, so both must
+    be correct even when fn and build describe the same wheel differently.
     """
     from conda_pypi.package_extractors.whl import extract_whl_as_conda_pkg
 
@@ -28,21 +36,17 @@ def test_extract_whl_sets_fn_correctly(
     with open(index_json_path) as f:
         index_data = json.load(f)
 
-    # Verify fn field is set correctly with build string and .whl extension
-    # Note: source.distribution returns the Python package name (with underscores),
-    # so fn will be "demo_package-0.1.0-pypi_0.whl" not "demo-package-0.1.0-pypi_0.whl"
+    # fn is the wheel basename on the path passed to extract_whl_as_conda_pkg (zip path).
+    # Repodata v3 matches: fn=requests-2.32.5-py3-none-any.whl, build=py3_none_any_0.
+    with WheelFile.open(pypi_demo_package_wheel_path) as source:
+        zip_basename = Path(source._zipfile.filename).name
     assert "fn" in index_data, "index.json should contain 'fn' field"
-    # The fn field should include the build string and .whl extension
-    assert index_data["fn"].endswith("-pypi_0.whl")
-    # Verify the format is name-version-build.whl
-    fn_parts = index_data["fn"].replace(".whl", "").rsplit("-", 2)
-    assert len(fn_parts) == 3
-    fn_name, fn_version, fn_build = fn_parts
-    assert fn_build == "pypi_0"
+    assert index_data["fn"] == pypi_demo_package_wheel_path.name
+    assert index_data["fn"] == zip_basename
 
-    # Verify other fields
-    # The name field uses the Python package name (with underscores)
+    # build from WHEEL Tag; build_number from WHEEL Build when present (PEP 427).
+    # The name field uses the Python package name from METADATA (underscores, not normalized).
     assert index_data["name"] == "demo_package"
     assert index_data["version"] == "0.1.0"
-    assert index_data["build"] == "pypi_0"
+    assert index_data["build"] == "py3_none_any_0"
     assert index_data["build_number"] == 0

--- a/tests/test_conda_meta_json_filename.py
+++ b/tests/test_conda_meta_json_filename.py
@@ -11,7 +11,24 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from installer.sources import WheelFile
+
+
+@pytest.mark.parametrize(
+    ("wheel_tag", "expected"),
+    [
+        ("py3-none-any", "py3-none-any"),
+        ("py2-none-any", "py3-none-any"),
+        ("py38-none-any", "py3-none-any"),
+        ("cp312-cp312-win_amd64", "cp312-cp312-win_amd64"),
+    ],
+)
+def test_noarch_wheel_tag_normalization_for_index_build(wheel_tag, expected):
+    normalized = wheel_tag
+    if normalized != "py3-none-any" and normalized.endswith("-none-any"):
+        normalized = "py3-none-any"
+    assert normalized == expected
 
 
 def test_extract_whl_sets_fn_correctly(

--- a/tests/test_conda_meta_json_filename.py
+++ b/tests/test_conda_meta_json_filename.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 
+from conda_pypi.package_extractors.whl import extract_whl_as_conda_pkg
+
 
 def _make_wheel(
     path: Path,
@@ -68,8 +70,6 @@ def test_extract_whl_index_json_build_from_wheel_metadata(
     wheel_build: str | None,
     expected_build: str,
 ):
-    from conda_pypi.package_extractors.whl import extract_whl_as_conda_pkg
-
     name = "test_pkg"
     version = "1.0.0"
     wheel_path = _make_wheel(tmp_path, name, version, tags, wheel_build=wheel_build)
@@ -96,8 +96,6 @@ def test_extract_whl_sets_fn_correctly(
     are not interchangeable — lockfile restore reads index.json directly, so both must
     be correct even when fn and build describe the same wheel differently.
     """
-    from conda_pypi.package_extractors.whl import extract_whl_as_conda_pkg
-
     extract_whl_as_conda_pkg(pypi_demo_package_wheel_path, tmp_path)
 
     # Check that index.json was created with correct fn field

--- a/tests/test_conda_meta_json_filename.py
+++ b/tests/test_conda_meta_json_filename.py
@@ -23,6 +23,7 @@ from conda_pypi.package_extractors.whl import (
 if TYPE_CHECKING:
     from email.message import Message
 
+
 def _make_wheel_meta(
     tags: list[str] | None = None,
     wheel_build: str | None = None,
@@ -65,13 +66,16 @@ def test_create_build_string_from_wheel_meta_and_filename_(
     assert build_number == expected_build_number
 
 
-@pytest.mark.parametrize(("filename", "expected_build"), [
-    ("test_pkg-1.0.0-py3-none-any.whl", "py3_none_any_0"),
-    ("test_pkg-1.0.0-py38-none-any.whl", "py3_none_any_0"),
-    ("test_pkg-1.0.0-py2-none-any.whl", "py3_none_any_0"),
-    ("test_pkg-1.0.0-py2.py3-none-any.whl", "py3_none_any_0"),
-    ("test_pkg-1.0.0-cp312-cp312-win_amd64.whl", "cp312_cp312_win_amd64_0"),
-])
+@pytest.mark.parametrize(
+    ("filename", "expected_build"),
+    [
+        ("test_pkg-1.0.0-py3-none-any.whl", "py3_none_any_0"),
+        ("test_pkg-1.0.0-py38-none-any.whl", "py3_none_any_0"),
+        ("test_pkg-1.0.0-py2-none-any.whl", "py3_none_any_0"),
+        ("test_pkg-1.0.0-py2.py3-none-any.whl", "py3_none_any_0"),
+        ("test_pkg-1.0.0-cp312-cp312-win_amd64.whl", "cp312_cp312_win_amd64_0"),
+    ],
+)
 def test_create_build_string_from_wheel_meta_and_filename_filename_fallback(
     filename: str,
     expected_build: str,
@@ -83,7 +87,6 @@ def test_create_build_string_from_wheel_meta_and_filename_filename_fallback(
     )
     assert build_string == expected_build
     assert build_number == 0
-
 
 
 def test_extract_whl_sets_fn_correctly(

--- a/tests/test_conda_meta_json_filename.py
+++ b/tests/test_conda_meta_json_filename.py
@@ -9,26 +9,80 @@ field repodata v3 uses (PyPI upload filename).
 from __future__ import annotations
 
 import json
+import zipfile
 from pathlib import Path
 
 import pytest
-from installer.sources import WheelFile
+
+
+def _make_wheel(
+    path: Path,
+    name: str,
+    version: str,
+    tags: list[str],
+    filename_tag: str | None = None,
+    wheel_build: str | None = None,
+) -> Path:
+    """Minimal installable wheel for extract_whl_as_conda_pkg (Tag/Build/RECORD/pkg).
+
+    Separate from tests/cli/test_index.py make_wheel, which targets indexing only.
+    """
+    if filename_tag is None:
+        filename_tag = "py3-none-any" if "py3-none-any" in tags else tags[0]
+    wheel_path = path / f"{name}-{version}-{filename_tag}.whl"
+    dist_info = f"{name}-{version}.dist-info"
+    wheel_lines = ["Wheel-Version: 1.0\nGenerator: test\n"]
+    for tag in tags:
+        wheel_lines.append(f"Tag: {tag}\n")
+    if wheel_build is not None:
+        wheel_lines.append(f"Build: {wheel_build}\n")
+    metadata = "\n".join(
+        [
+            "Metadata-Version: 2.1",
+            f"Name: {name}",
+            f"Version: {version}",
+        ]
+    )
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr("pkg.py", "# pkg\n")
+        zf.writestr(f"{dist_info}/METADATA", metadata)
+        zf.writestr(f"{dist_info}/WHEEL", "".join(wheel_lines))
+        zf.writestr(f"{dist_info}/top_level.txt", "pkg\n")
+        zf.writestr(f"{dist_info}/RECORD", "pkg.py,,\n")
+    return wheel_path
 
 
 @pytest.mark.parametrize(
-    ("wheel_tag", "expected"),
+    ("tags", "wheel_build", "expected_build"),
     [
-        ("py3-none-any", "py3-none-any"),
-        ("py2-none-any", "py3-none-any"),
-        ("py38-none-any", "py3-none-any"),
-        ("cp312-cp312-win_amd64", "cp312-cp312-win_amd64"),
+        (["py2-none-any"], None, "py3_none_any_0"),
+        (["py38-none-any"], None, "py3_none_any_0"),
+        (["py2-none-any", "py3-none-any"], None, "py3_none_any_0"),
+        (["py3-none-any"], "1", "py3_none_any_1"),
+        (["cp312-cp312-win_amd64"], None, "cp312_cp312_win_amd64_0"),
     ],
 )
-def test_noarch_wheel_tag_normalization_for_index_build(wheel_tag, expected):
-    normalized = wheel_tag
-    if normalized != "py3-none-any" and normalized.endswith("-none-any"):
-        normalized = "py3-none-any"
-    assert normalized == expected
+def test_extract_whl_index_json_build_from_wheel_metadata(
+    tmp_path: Path,
+    tags: list[str],
+    wheel_build: str | None,
+    expected_build: str,
+):
+    from conda_pypi.package_extractors.whl import extract_whl_as_conda_pkg
+
+    name = "test_pkg"
+    version = "1.0.0"
+    wheel_path = _make_wheel(tmp_path, name, version, tags, wheel_build=wheel_build)
+    extract_dir = tmp_path / "extract"
+    extract_whl_as_conda_pkg(wheel_path, extract_dir)
+
+    index_data = json.loads((extract_dir / "info" / "index.json").read_text())
+    expected_build_number = int(wheel_build) if wheel_build is not None else 0
+    assert index_data["name"] == name
+    assert index_data["version"] == version
+    assert index_data["fn"] == wheel_path.name
+    assert index_data["build"] == expected_build
+    assert index_data["build_number"] == expected_build_number
 
 
 def test_extract_whl_sets_fn_correctly(
@@ -50,16 +104,12 @@ def test_extract_whl_sets_fn_correctly(
     index_json_path = tmp_path / "info" / "index.json"
     assert index_json_path.exists()
 
-    with open(index_json_path) as f:
-        index_data = json.load(f)
+    index_data = json.loads(index_json_path.read_text())
 
-    # fn is the wheel basename on the path passed to extract_whl_as_conda_pkg (zip path).
+    # fn is the wheel basename on the path passed to extract_whl_as_conda_pkg.
     # Repodata v3 matches: fn=requests-2.32.5-py3-none-any.whl, build=py3_none_any_0.
-    with WheelFile.open(pypi_demo_package_wheel_path) as source:
-        zip_basename = Path(source._zipfile.filename).name
     assert "fn" in index_data, "index.json should contain 'fn' field"
     assert index_data["fn"] == pypi_demo_package_wheel_path.name
-    assert index_data["fn"] == zip_basename
 
     # build from WHEEL Tag; build_number from WHEEL Build when present (PEP 427).
     # The name field uses the Python package name from METADATA (underscores, not normalized).

--- a/tests/test_conda_meta_json_filename.py
+++ b/tests/test_conda_meta_json_filename.py
@@ -48,7 +48,7 @@ def _make_wheel_meta(
         (["cp312-cp312-win_amd64"], None, "cp312_cp312_win_amd64_0"),
     ],
 )
-def test_create_build_string_from_wheel_meta_and_filename_(
+def test_create_build_string_from_wheel_meta_and_filename(
     tags: list[str],
     wheel_build: str | None,
     expected_build: str,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes #417.

- Added parsing code to look at WHEEL meta data for wheel packages.
- Opinionated choices when more than one tag is present.
- Leverage build_number if provided and conda can use it (aka pure numeric).
- Updated tests.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
