### PR TITLE
Fix beta tip not visible at default verbosity

### DIFF
--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -153,7 +153,7 @@ def notify_externally_managed_future(command: str):
         return
 
     if context.plugins.conda_pypi_pip_warning:
-        logger.info(
+        logger.warning(
             "\n"
             "  Did you know? You can install many PyPI packages with conda\n"
             "  using the conda-pypi beta. Get started:\n"

--- a/news/437-pip-beta-tip-visibility
+++ b/news/437-pip-beta-tip-visibility
@@ -1,3 +1,0 @@
-### Bug fixes
-
-* Restore visibility of the conda-pypi beta tip at default conda verbosity by logging it at WARNING instead of INFO.

--- a/news/437-pip-beta-tip-visibility
+++ b/news/437-pip-beta-tip-visibility
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Restore visibility of the conda-pypi beta tip at default conda verbosity by logging it at WARNING instead of INFO.

--- a/news/443-pip-beta-tip-visibility
+++ b/news/443-pip-beta-tip-visibility
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Restore visibility of the conda-pypi beta tip at default conda verbosity by logging it at WARNING instead of INFO. (#442 via #443)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -80,8 +80,8 @@ def test_notify_logs_tip_when_pip_installed(
 
     notify_externally_managed_future(command)
 
-    mock_logger.info.assert_called_once()
-    mock_logger.warning.assert_not_called()
+    mock_logger.warning.assert_called_once()
+    mock_logger.info.assert_not_called()
 
 
 def test_notify_skips_build_env(
@@ -100,7 +100,7 @@ def test_notify_skips_build_env(
 
     notify_externally_managed_future("install")
 
-    mock_logger.info.assert_not_called()
+    mock_logger.warning.assert_not_called()
 
 
 def test_notify_skips_base_prefix(
@@ -117,7 +117,7 @@ def test_notify_skips_base_prefix(
 
     notify_externally_managed_future("install")
 
-    mock_logger.info.assert_not_called()
+    mock_logger.warning.assert_not_called()
 
 
 def test_notify_skips_no_pip(
@@ -132,7 +132,7 @@ def test_notify_skips_no_pip(
 
     notify_externally_managed_future("install")
 
-    mock_logger.info.assert_not_called()
+    mock_logger.warning.assert_not_called()
 
 
 def test_notify_skips_when_pip_warning_disabled(
@@ -151,7 +151,18 @@ def test_notify_skips_when_pip_warning_disabled(
 
     notify_externally_managed_future("install")
 
-    mock_logger.info.assert_not_called()
+    mock_logger.warning.assert_not_called()
+
+
+def test_pip_beta_tip_visible_at_default_verbosity(
+    conda_cli: CondaCLIFixture,
+    tmp_path: Path,
+):
+    """The beta tip must appear at default conda verbosity (not only with -vv)."""
+    prefix = tmp_path / "env"
+    _, err, rc = conda_cli("create", "--prefix", str(prefix), "--yes", "python", "pip")
+    assert rc == 0
+    assert "Did you know?" in err
 
 
 def test_pip_warning_setting_defaults_to_true():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Fixes #442 by restoring the visibility level of the tip from INFO to WARNING.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
