### PR TITLE
Add `extras` (with CEP44 spelling) back in convert logic

### DIFF
--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -16,6 +16,7 @@ from conda.models.match_spec import MatchSpec
 from packaging.requirements import Requirement
 
 from conda_pypi import __version__
+from conda_pypi.markers import dependency_extras_suffix
 from conda_pypi.name_mapping import conda_to_pypi_name, pypi_to_conda_name
 
 log = logging.getLogger(__name__)
@@ -244,10 +245,12 @@ def requires_to_conda(
     for requirement in [Requirement(dep) for dep in requires or []]:
         # Use parsed Requirement.name so unmapped conda names preserve dots (lookup still canonicalizes).
         requirement.name = pypi_to_conda_name(requirement.name, pypi_to_conda_name_mapping)
-        # PEP 508 optional dependency extras (e.g. requests[security]) are intentionally
-        # omitted here; wheel → .conda convert does not emit MatchSpec extras=[…] yet
-        # (see #468). Wheel repodata uses dependency_extras_suffix / pypi_to_repodata.
-        as_conda = requirement.name + str(requirement.specifier)
+        # PEP 508 name extras → MatchSpec extras=[…] (same as pypi_to_repodata).
+        as_conda = (
+            requirement.name
+            + str(requirement.specifier)
+            + dependency_extras_suffix(requirement.extras)
+        )
 
         # Wheel METADATA → conda depends: do not emit ``[when=…]`` (conda MatchSpec does not
         # parse it yet). Match main: only ``extra == …`` is routed to the extras map.

--- a/docs/developer/marker-conversion.md
+++ b/docs/developer/marker-conversion.md
@@ -20,7 +20,7 @@ In the context of environment markers above, one of them is called `extra`. For 
 
 Syntax such as `httpx[cli]` denotes PEP 508 optional extras on the dependency name. This syntax means that we want `httpx` with an optional group of dependencies called `cli`. The [dependency specifier grammar](https://packaging.python.org/en/latest/specifications/dependency-specifiers/) allows a comma-separated list of extra names.
 
-When doing wheel to conda package conversion, the brackets are dropped, for example `httpx[cli]>=0.24` becomes `httpx>=0.24`. {py:func}`conda_pypi.translate.requires_to_conda` keeps only the base package name and version specifier.
+When doing wheel to conda package conversion, PEP 508 name extras are translated to MatchSpec form, for example `httpx[cli]>=0.24` becomes `httpx>=0.24[extras=[cli]]`. {py:func}`conda_pypi.translate.requires_to_conda` emits the same `extras=[…]` spelling as wheel repodata.
 
 For creating repodata, PEP 508 name extras are translated to [CEP 44](https://conda.org/learn/ceps/cep-0044) MatchSpec form. For example, `httpx[cli]>=0.24` becomes `httpx>=0.24[extras=[cli]]` (multiple extras are sorted). This is done by {py:func}`conda_pypi.pypi_metadata.pypi_to_repodata` which handles the bracket extras syntax (including {py:func}`conda_pypi.markers.dependency_extras_suffix` for optional dependency extras).
 

--- a/news/468-convert-matchspec-extras
+++ b/news/468-convert-matchspec-extras
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Emit MatchSpec `extras=[…]` for optional dependency extras when converting wheels to `.conda` packages (`requires_to_conda`).
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pixi.lock
+++ b/pixi.lock
@@ -11919,8 +11919,8 @@ packages:
   timestamp: 1781293054998
 - pypi: ./
   name: conda-pypi
-  version: 0.10.2.dev31+g8a3f1a4fe.d20260724
-  sha256: 2554ac650dd3763b65fee486850fcfc869d941864db25f8e13c4840dd6d4cee2
+  version: 0.10.2.dev37+g9508ef1f9
+  sha256: 80b5beb44950d2d966e89c6a5c1e8caa395e9b4f12f741cefb8bd1a3547d71c1
   requires_dist:
   - build
   - conda-index>=0.12.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -11919,8 +11919,8 @@ packages:
   timestamp: 1781293054998
 - pypi: ./
   name: conda-pypi
-  version: 0.10.2.dev37+g9508ef1f9
-  sha256: 80b5beb44950d2d966e89c6a5c1e8caa395e9b4f12f741cefb8bd1a3547d71c1
+  version: 0.10.2.dev31+g8a3f1a4fe.d20260724
+  sha256: 2554ac650dd3763b65fee486850fcfc869d941864db25f8e13c4840dd6d4cee2
   requires_dist:
   - build
   - conda-index>=0.12.0

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -118,14 +118,14 @@ def test_requires_to_conda_unmapped_dotted_name_preserves_dots():
     assert requires[0] == "jaraco.tidelift>=1"
 
 
-def test_requires_to_conda_omits_pep508_dependency_extras_for_rattler():
-    """PEP 508 optional dependency extras are omitted from depends on the convert path."""
+def test_requires_to_conda_emits_matchspec_dependency_extras():
+    """PEP 508 name extras become MatchSpec extras=[…] on the convert path."""
     requires, extras_map = requires_to_conda(
         ["httpx[cli,http2]>=0.24.0", 'requests[socks]>=2.0; extra == "dev"'],
     )
-    assert requires == ["httpx>=0.24.0"]
+    assert requires == ["httpx>=0.24.0[extras=[cli,http2]]"]
     assert "dev" in extras_map
-    assert extras_map["dev"] == ["requests>=2.0"]
+    assert extras_map["dev"] == ["requests>=2.0[extras=[socks]]"]
 
 
 def test_requires_to_conda_marker_extra_and_platform():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
resolves #468 

Blocked on https://github.com/conda/conda/issues/16073

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
