### PR TITLE
Drop legacy extras suffix from console_scripts entry points

### DIFF
--- a/conda_pypi/translate.py
+++ b/conda_pypi/translate.py
@@ -169,8 +169,13 @@ class CondaMetadata:
         # conda does support ~=3.0.0 "compatibility release" matches
         depends = [requires_python] + requirements
 
+        # Use module/attr rather than ep.value: value retains the legacy extras
+        # suffix (``mod:func [extra]``), which conda's noarch entry-point parser
+        # rejects at link time. The spec asks consumers to parse extras and allows
+        # ignoring them, which is what dropping them here does.
+        # https://packaging.python.org/en/latest/specifications/entry-points/#file-format
         console_scripts = [
-            f"{ep.name} = {ep.value}"
+            f"{ep.name} = {ep.module}:{ep.attr}"
             for ep in distribution.entry_points
             if ep.group == "console_scripts"
         ]

--- a/news/477-entry-point-extras
+++ b/news/477-entry-point-extras
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Drop the legacy extras suffix from `console_scripts` entry points during conversion (e.g. `mod:func [extra]` → `mod:func`). Previously it was copied verbatim into `info/link.json`, making the resulting package fail to install with `ValueError: '<func> [<extra>]' is not a valid Python function identifier` at link time. (#477)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -143,7 +143,24 @@ def test_requires_to_conda_marker_extra_and_platform():
     assert requires == []
 
 
-def _distribution(project_urls=(), description=None, requires_python=None):
+class _EntryPointDistribution(FileDistribution):
+    """FileDistribution that also serves an ``entry_points.txt``.
+
+    ``FileDistribution.read_text`` only answers for ``METADATA``, so
+    ``distribution.entry_points`` is otherwise always empty.
+    """
+
+    def __init__(self, raw_text, entry_points_txt):
+        super().__init__(raw_text)
+        self.entry_points_txt = entry_points_txt
+
+    def read_text(self, filename: str):
+        if filename == "entry_points.txt":
+            return self.entry_points_txt
+        return super().read_text(filename)
+
+
+def _distribution(project_urls=(), description=None, requires_python=None, console_scripts=None):
     """Build a FileDistribution with the given Project-URL labels."""
     header = [
         "Metadata-Version: 2.1\n",
@@ -156,7 +173,11 @@ def _distribution(project_urls=(), description=None, requires_python=None):
     if description is not None:
         header.append("Description: " + description.replace("\n", "\n        ") + "\n")
     urls = "".join(f"Project-URL: {label}, {url}\n" for label, url in project_urls)
-    return FileDistribution("".join(header) + urls + "\n")
+    metadata = "".join(header) + urls + "\n"
+    if console_scripts is None:
+        return FileDistribution(metadata)
+    body = "".join(f"{name} = {value}\n" for name, value in console_scripts.items())
+    return _EntryPointDistribution(metadata, f"[console_scripts]\n{body}")
 
 
 @pytest.mark.parametrize(
@@ -246,3 +267,34 @@ def test_invalid_requires_python_filtered(caplog):
         metadata = CondaMetadata.from_distribution(dist)
     assert metadata.package_record.depends[0] == "python"
     assert "invalid Requires-Python" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Legacy setuptools extras suffix must not reach info/link.json: conda's
+        # noarch entry-point parser rejects it at link time. Real-world cases:
+        # mcp 1.27.2 and google-auth-oauthlib 1.4.0.
+        ("mcp.cli:app [cli]", "demo-script = mcp.cli:app"),
+        ("pkg.tool.__main__:main [tool]", "demo-script = pkg.tool.__main__:main"),
+        ("pkg.mod:func [a,b]", "demo-script = pkg.mod:func"),
+        # No extras: unchanged.
+        ("pkg.mod:func", "demo-script = pkg.mod:func"),
+    ],
+)
+def test_console_scripts_drop_entry_point_extras(value, expected):
+    """Entry-point extras are parsed and dropped rather than passed through."""
+    dist = _distribution(console_scripts={"demo-script": value})
+    assert CondaMetadata.from_distribution(dist).console_scripts == [expected]
+
+
+def test_link_json_entry_points_are_parseable_by_conda():
+    """The emitted link.json entry point survives conda's own parser."""
+    from conda.common.path.python import parse_entry_point_def
+
+    dist = _distribution(console_scripts={"demo-script": "pkg.cli:app [cli]"})
+    link_json = CondaMetadata.from_distribution(dist).link_json()
+    for entry_point in link_json["noarch"]["entry_points"]:
+        # Raises ValueError for "app [cli]" before this fix.
+        command, module, func = parse_entry_point_def(entry_point)
+        assert (command, module, func) == ("demo-script", "pkg.cli", "app")


### PR DESCRIPTION
Fixes #477.

### Problem

`CondaMetadata.from_distribution` built each console script from `ep.value`, which retains the legacy setuptools extras suffix:

```python
f"{ep.name} = {ep.value}"        # ep.value == "mcp.cli:app [cli]"
```

That string lands verbatim in `info/link.json` → `noarch.entry_points`. conda's `parse_entry_point_def()` then splits on `:` and validates the remainder as a Python identifier, so `app [cli]` raises — **at link time, after the solve has already succeeded**, which surfaces as a generic conda crash report rather than a metadata error.

Observed on two wheel-converted packages:

| package | entry point | error |
|---|---|---|
| `mcp` 1.27.2 | `mcp = mcp.cli:app [cli]` | `ValueError: 'app [cli]' is not a valid Python function identifier` |
| `google-auth-oauthlib` 1.4.0 | `google-oauthlib-tool = ...:main [tool]` | `ValueError: 'main [tool]' is not a valid …` |

### Fix

Use `ep.module` / `ep.attr` — `importlib.metadata.EntryPoint` already parses the three parts and exposes extras separately:

| `ep.value` | `.module` | `.attr` | `.extras` |
|---|---|---|---|
| `mcp.cli:app [cli]` | `mcp.cli` | `app` | `['cli']` |
| `pkg.mod:func` | `pkg.mod` | `func` | `[]` |

This also brings the two conversion paths into line — `package_extractors/whl.py::write_script()` was already composing from `module`/`attr`, so it never had the bug.

Dropping extras is what the spec asks of consumers, per [PyPA entry-points](https://packaging.python.org/en/latest/specifications/entry-points/#file-format):

> Using extras for an entry point is no longer recommended. **Consumers should support parsing them from existing distributions, but may then ignore them.** New publishing tools need not support specifying extras.

### Tests

- `test_console_scripts_drop_entry_point_extras` — parametrized over `[cli]`, `[tool]`, `[a,b]`, and the no-extras case (which must stay unchanged).
- `test_link_json_entry_points_are_parseable_by_conda` — feeds the emitted `link.json` through conda's own `parse_entry_point_def()`, so a regression is caught by the real parser rather than a string comparison.

Both fail on `main` and pass with this change. Full `tests/test_translate.py` is green (34 passed).

`FileDistribution.read_text` only answers for `METADATA`, so `distribution.entry_points` was always empty in tests — the `_distribution()` helper gained an optional `console_scripts` argument backed by a small subclass that also serves `entry_points.txt`.
