### PR TITLE
Add workflow concurrency limits

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,6 +9,10 @@ on:
     types:
       - published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.release.tag_name || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Add event-aware concurrency to the PyPI workflow. Pull request updates cancel obsolete build runs, while release publications use the release tag and are never canceled.

Part of conda/infrastructure#706

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist - did you ...

- [x] ~~Add a file to the news directory for the next release's release notes~~
- [x] ~~Add or update necessary tests~~
- [x] ~~Add or update outdated documentation~~
