### PR TITLE
Remove check authors workflow template

### DIFF
--- a/.github/template-files/config.yml
+++ b/.github/template-files/config.yml
@@ -22,6 +22,10 @@ conda/infrastructure:
     with:
       tests_workflow: Test
 
+  # remove check-authors workflow if it has already been synced
+  - dst: .github/workflows/check-authors.yml
+    remove: true
+
   # [optional] keep .authors.yml current (weekly PR)
   - src: templates/workflows/prepare-authors.yml
     dst: .github/workflows/prepare-authors.yml

--- a/.github/template-files/config.yml
+++ b/.github/template-files/config.yml
@@ -22,10 +22,6 @@ conda/infrastructure:
     with:
       tests_workflow: Test
 
-  # [optional] validate .authors.yml on PRs
-  - src: templates/workflows/check-authors.yml
-    dst: .github/workflows/check-authors.yml
-
   # [optional] keep .authors.yml current (weekly PR)
   - src: templates/workflows/prepare-authors.yml
     dst: .github/workflows/prepare-authors.yml


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I noticed in #502, that the check-authors workflow is failing. We already have prepare-authors which will update the authors weekly. This workflow isn't merged yet, but if we did merge it, the check would fail every time a PR is opened from a new person. I don't think we want that.

We could run this only on release branches to ensure the authors stay current like prepare-release does, but let's remove it for now and I can run through the prepare-news and prepare-release workflows to see how it works.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
