### PR TITLE
Clarify Python packaging terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 * Correct marker-conversion docs for MatchSpec `[when=…]` support and link CEP 43. (#472)
 * Document that the `conda_pypi_pip_warning` tip is triggered by a new `pip` install, not by `pip` merely being present. (#484)
+* Clarify terminology for distribution packages, package indexes, distribution formats, and package installers. (#516)
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This is a **community-maintained** project under the [conda](https://github.com/
 
 ## What is this?
 
-The `conda-pypi` plugin improves conda's integration with the PyPI ecosystem. The most
+The `conda-pypi` plugin improves conda's integration with Python packaging tools. The most
 important feature is the `conda-pypi` channel, hosted by Anaconda, which makes pure
-Python pacakges from PyPi available to users natively through `conda install`.
+Python wheels from PyPI available to users natively through `conda install`.
 
 ## Using `conda-pypi`
 
@@ -45,38 +45,38 @@ Anaconda.org web UI and some commands such as `conda search` can fail because
 they request classic `repodata.json` metadata. Use `conda install` or
 `conda create --dry-run` to check whether the solver can use the channel.
 
-After configuring, you can use PyPI packages alongside conda packages in
-your normal conda workflows, without needing to convert PyPI's wheel files
+After configuring, you can use packages from PyPI alongside conda packages in
+your normal conda workflows, without needing to convert the wheel files
 to conda files.
 
 ## Advanced options
 
-`conda-pypi` includes more advanced subcommand controls for working with PyPI
+`conda-pypi` includes more advanced subcommand controls for working with Python
 packages. These options are recommended for users who want to experiment with
 conda and wheels and work with cutting-edge plugin features.
 
 You can use the following commands with the `conda pypi` subcommand to do more
 with the `conda-pypi` plugin:
 
-- `conda pypi install`: Converts PyPI packages to `.conda` format for safer installation.
+- `conda pypi install`: Converts wheels from PyPI and other package indexes to `.conda` format for safer installation. PyPI is the default index. Use `--index-url` to select another index.
 - `conda pypi install -e .`: Converts a path to an editable `.conda` format package.
-- `conda pypi convert`: Convert PyPI packages to `.conda` format without installing them.
+- `conda pypi convert`: Convert Python projects to `.conda` format without installing them.
 - `conda pypi index`: Index a local directory of `.whl` files to create a local conda channel.
 - `conda install` from wheel channels (experimental): channels can serve pure Python wheels directly in `repodata.json`.
 - A warning when running `conda create` or `conda install` with `pip` in the environment.
 
 ## Why?
 
-Mixing conda and PyPI is often discouraged in the conda ecosystem.
+Mixing conda packages and packages installed with pip is often discouraged in the conda ecosystem.
 There are only a handful patterns that are safe to run. This tool
 aims to provide a safer way of keeping your conda environments functional
-while mixing it with PyPI dependencies. Refer to the [documentation](docs/)
+while adding Python distribution packages. Refer to the [documentation](docs/)
 for more details.
 
 ## Attribution
 
 - This project now incorporates [conda-pupa](https://github.com/dholth/conda-pupa)
-by Daniel Holth, which provides the core PyPI-to-conda conversion functionality.
+by Daniel Holth, which provides the core wheel-to-conda conversion functionality.
 - The conda-pypi platypus logo is by [James Turner](http://www.eruditebaboon.co.uk/).
 
 ## Contributing

--- a/conda_pypi/cli/convert.py
+++ b/conda_pypi/cli/convert.py
@@ -15,7 +15,7 @@ def configure_parser(parser: _SubParsersAction) -> None:
         """
         Examples:
 
-        Convert a PyPI package to conda format without installing::
+        Convert a local wheel to conda format without installing::
 
             conda pypi convert ./requests-2.32.5-py3-none-any.whl
 

--- a/conda_pypi/cli/install.py
+++ b/conda_pypi/cli/install.py
@@ -10,22 +10,23 @@ def configure_parser(parser: _SubParsersAction) -> None:
     """
     Configure all subcommand arguments and options via argparse
     """
-    summary = "Install PyPI packages as conda packages"
+    summary = "Install Python distribution packages as conda packages"
     description = summary
     epilog = dals(
         """
 
-        Install PyPI packages as conda packages.  Any dependencies that are
+        Install Python distribution packages as conda packages.  Dependencies that are
         available on the configured conda channels will be installed with `conda`,
-        while the rest will be converted to conda packages from PyPI.
+        while missing wheels will be fetched from the configured package indexes
+        and converted to conda packages. PyPI is the default index.
 
         Examples:
 
-        Install a single PyPI package into the current conda environment::
+        Install a single Python distribution package into the current conda environment::
 
             conda pypi install requests
 
-        Install multiple PyPI packages with specific versions::
+        Install multiple packages with specific versions::
 
             conda pypi install "numpy>=1.20" "pandas==1.5.0"
 
@@ -33,7 +34,7 @@ def configure_parser(parser: _SubParsersAction) -> None:
 
             conda pypi install -n myenv flask django
 
-        Install packages using only PyPI (skip configured conda channels)::
+        Install packages without searching configured conda channels::
 
             conda pypi install --ignore-channels fastapi
 
@@ -60,14 +61,14 @@ def configure_parser(parser: _SubParsersAction) -> None:
     install.add_argument(
         "--ignore-channels",
         action="store_true",
-        help="Do not search default or .condarc channels. Will search PyPI.",
+        help="Do not search default or .condarc channels. Will search the configured package indexes.",
     )
     install.add_argument(
         "-i",
         "--index-url",
         dest="index_urls",
         action="append",
-        help="Add a PyPI index URL (can be used multiple times).",
+        help="Package index URL to use instead of PyPI (can be used multiple times).",
     )
     output_and_prompt_options = add_output_and_prompt_options(install)
     # These options also exist on the parent parser. Suppressing subparser
@@ -78,7 +79,7 @@ def configure_parser(parser: _SubParsersAction) -> None:
         "packages",
         metavar="PACKAGE",
         nargs="*",
-        help="PyPI packages to install",
+        help="Python distribution packages to install",
     )
     target_env = install.add_mutually_exclusive_group()
     target_env.add_argument(

--- a/conda_pypi/plugin.py
+++ b/conda_pypi/plugin.py
@@ -18,7 +18,7 @@ def conda_subcommands():
         name="pypi",
         action=cli.main.execute,
         configure_parser=cli.main.configure_parser,
-        summary="Install PyPI packages as conda packages",
+        summary="Install Python distribution packages as conda packages",
     )
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,4 +117,6 @@ sitemap_url_scheme = "{link}"
 
 # -- For sphinx_reredirects ------------------------------------------------
 
-redirects = {}
+redirects = {
+    "why/conda-vs-pypi": "../conda-packages-and-wheels/",
+}

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -12,8 +12,8 @@ workflows without requiring modifications to conda itself.
 The plugin registers several hooks with `conda`'s plugin system. The
 subcommand hook adds the `conda pypi` subcommand to conda through
 `conda_pypi.plugin.conda_subcommands()`, providing `conda pypi install`
-for installing PyPI packages with conversion (pending deprecation), `conda pypi convert` for
-converting PyPI packages without installing them, and `conda pypi index` for indexing a local directory of `.whl` files to create a local conda channel.
+for installing Python distribution packages with conversion (pending deprecation), `conda pypi convert` for
+converting Python projects without installing them, and `conda pypi index` for indexing a local directory of `.whl` files to create a local conda channel.
 
 The plugin also registers two post-command hooks that extend conda's
 existing commands. The environment protection hook triggers after `install`,
@@ -40,7 +40,7 @@ Dependency Resolution
          ↓
 Channel Search for Dependencies
          ↓
-Convert Missing from PyPI
+Convert Missing Wheels from Package Indexes
          ↓
 Install via conda
          ↓
@@ -88,30 +88,30 @@ install/      install/create/
 create        update/remove
     ↓           ↓
 Process       Deploy
-PyPI          EXTERNALLY-
-lines         MANAGED
+requirements  EXTERNALLY-
+from indexes  MANAGED
     ↓           ↓
 Install       Create marker
-PyPI          files
-packages
+packages      files
+from indexes
 ```
 
 ## Key Design Principles
 
 The architecture of `conda-pypi` is built around several key design
-principles that ensure effective integration between conda and PyPI
-ecosystems.
+principles that ensure effective integration between conda and Python
+packaging tools.
 
 Conda-native integration is achieved by using `conda`'s official plugin
 system and leveraging `conda`'s existing infrastructure including solvers,
 channels, and metadata systems. This approach maintains full compatibility
 with existing conda workflows.
 
-This hybrid approach ensures that explicit packages always come
-from PyPI to respect user intent, while dependencies prefer conda channels
-for ecosystem compatibility. The system falls back to PyPI conversion only
+This hybrid approach resolves packages from conda channels and the local
+conversion cache, then fetches missing wheels from package indexes
+(PyPI by default). The system falls back to wheel conversion only
 when needed.
 
 This architecture enables conda-pypi to provide a seamless bridge between
-the conda and PyPI ecosystems while maintaining the integrity and benefits of
+conda and Python packaging tools while maintaining the integrity and benefits of
 both package management systems.

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -84,7 +84,7 @@ conda-pypi/
 │   ├── plugin.py        # Conda plugin registration
 │   ├── cli/             # Command-line interface
 │   ├── build.py         # Wheel to conda conversion
-│   ├── translate.py     # PyPI ↔ Conda metadata translation
+│   ├── translate.py     # Python ↔ conda package metadata translation
 │   ├── name_mapping.py  # Grayskull PyPI → conda package names
 │   ├── markers.py       # PEP 508 markers → `[when=…]` on repodata
 │   ├── convert_tree.py  # Dependency resolution

--- a/docs/developer/marker-conversion.md
+++ b/docs/developer/marker-conversion.md
@@ -4,7 +4,7 @@ This page documents how conda-pypi translates PEP 508 environment markers for re
 
 ## Context
 
-PyPI [environment markers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers) (`python_version`, `sys_platform`, `extra`, and related variables) are not valid conda `MatchSpec` syntax on their own. For wheel repodata from {py:func}`conda_pypi.pypi_metadata.pypi_to_repodata`, conda-pypi does emit `[when="…"]` on dependency strings and `extra_depends` tables so that the Rattler solver can use them. The inner condition is JSON-encoded (`json.dumps`) so nested quotes are safe.
+PEP 508 [environment markers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers) (`python_version`, `sys_platform`, `extra`, and related variables) are not valid conda `MatchSpec` syntax on their own. For wheel repodata from {py:func}`conda_pypi.pypi_metadata.pypi_to_repodata`, conda-pypi does emit `[when="…"]` on dependency strings and `extra_depends` tables so that the Rattler solver can use them. The inner condition is JSON-encoded (`json.dumps`) so nested quotes are safe.
 
 When building `.conda` packages from wheel `METADATA` ({py:func}`conda_pypi.translate.requires_to_conda`), markers are not encoded as `[when="…"]` on `depends`. The PEP 508 marker `extra == "…"` is split into the per-extra requirement map. Other marker dimensions are omitted from `depends`.
 

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -27,7 +27,7 @@ the release number from earlier. Ensure that this workflow completes successfull
 
 ### 1.c Ensure the package is available on PyPI
 
-Check that the PyPI package has been updated at https://pypi.org/project/conda-pypi/.
+Check that the release has been published at https://pypi.org/project/conda-pypi/.
 You should see that version matches the release version and that the wheel is available
 in the [download files](https://pypi.org/project/conda-pypi/#files) section.
 

--- a/docs/developer/testing/index.md
+++ b/docs/developer/testing/index.md
@@ -91,7 +91,7 @@ Tests are organized in the `tests/` directory:
 tests/
 ├── conftest.py              # Shared fixtures and configuration
 ├── cli/                     # CLI-specific tests
-├── pypi_local_index/        # Local PyPI server data
+├── pypi_local_index/        # Local package index data
 ├── conda_local_channel/     # Local conda channel data
 └── test_*.py                # Test modules
 ```
@@ -129,13 +129,15 @@ def test_build_conda_package(tmp_path):
 
 Common fixtures are defined in `tests/conftest.py`:
 
-#### PyPI Local Index
+(pypi-local-index)=
 
-The `pypi_local_index` fixture provides a local PyPI server for testing without network access:
+#### Local package index
+
+The `pypi_local_index` fixture provides a local package index for testing without network access:
 
 ```python
 def test_with_local_pypi(pypi_local_index):
-    """Test using the local PyPI index."""
+    """Test using the local package index."""
     # pypi_local_index is a URL like "http://localhost:8035"
     # Use this in place of real PyPI for offline testing
     pass
@@ -224,7 +226,7 @@ def test_conda_pypi_install(conda_cli, tmp_env):
 
 The test suite uses local HTTP servers to avoid network dependencies:
 
-- **PyPI Server**: Serves packages from `tests/pypi_local_index/`
+- **Package index**: Serves packages from `tests/pypi_local_index/`
 - **Conda Channel Server**: Serves packages from `tests/conda_local_channel/`
 
 For more information on the conda channel server, see the [Mock Channel Server Guide](mock-channel-server.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,11 +1,11 @@
 # Features
 
 `conda-pypi` uses the `conda` plugin system to implement several features
-that better improve the `conda` integration with the PyPI ecosystem. This
+that better improve the `conda` integration with Python packaging tools. This
 page is divided into basic and advanced sections to help you discover
 which features are best for you.
 
-- **Basic**: For users who just want to use conda and wheels packages
+- **Basic**: For users who just want to use conda packages and wheels
   together with no changes to their overall workflow.
 - **Advanced**: For users who want to experiment with conda and wheels
   and work with cutting-edge plugin features.
@@ -51,9 +51,9 @@ pypi.org.
 
 ### The `conda pypi` subcommand
 
-This subcommand provides a safer way to install PyPI packages in conda
+This subcommand provides a safer way to install Python distribution packages in conda
 environments by converting them to `.conda` format when possible. It offers three
-main subcommands that handle different aspects of PyPI integration.
+main subcommands that handle different aspects of Python packaging integration.
 
 #### `conda pypi install`
 
@@ -63,15 +63,20 @@ main subcommands that handle different aspects of PyPI integration.
 The `conda pypi install` command is pending deprecation and will be removed in version 27.9. Use `conda install` with `conda-pypi` channel configuration instead.
 :::
 
-The install command takes PyPI packages and converts them to `.conda` format.
-Explicitly requested packages are always installed from PyPI and converted
-to `.conda` format to ensure you get exactly what you asked for. For
+The install command fetches missing wheels from PyPI and other package indexes and
+converts them to `.conda` format. It resolves the requested packages using
+the configured conda channels and the local conversion cache. For
 dependencies, `conda-pypi` chooses the best source using a
 conda-first approach. If a dependency is available on conda channels, it will
 be installed with `conda` directly. If not available on conda channels, the
-dependency is converted from PyPI to `.conda` format.
+dependency is fetched from the configured package indexes and converted to `.conda` format.
 
-PyPI names are mapped to conda names with a bundled Grayskull table, plus a
+PyPI is the default package index. Use `--index-url` to select another
+index for wheel downloads, including missing dependencies. Repeat the option
+to search multiple indexes. Providing this option replaces the default PyPI
+index list. It does not configure editable builds or local conversion.
+
+Project names on PyPI are mapped to conda package names with a bundled Grayskull table, plus a
 simple normalization rule when a package is not listed. `conda pypi convert` can
 load a replacement table from a JSON file via `--name-mapping`. With `-e` /
 `--editable`, a `.conda` package containing a link to the local project
@@ -80,13 +85,13 @@ directory is built and installed using [PEP
 
 You can preview what would be installed without making changes using
 `--dry-run`, install packages in editable development mode with `--editable`
-or `-e`, and force dependency resolution from PyPI without using conda
-channels using `--ignore-channels`.
+or `-e`, and search the configured package indexes without searching
+configured conda channels using `--ignore-channels`.
 
 #### `conda pypi convert`
 
-The convert command transforms PyPI packages to `.conda` format without
-installing them, which is useful for creating conda packages from PyPI
+The convert command transforms Python projects to `.conda` format without
+installing them, which is useful for creating conda packages from Python
 distributions or preparing packages for offline installation. You can specify
 where to save the converted packages using `-d`, `--dest`, or `--output-dir`.
 The command supports converting multiple packages at once and can skip conda
@@ -123,12 +128,14 @@ conda pypi index path/to/my_wheels/
 conda install -c file:///path/to/my_wheels some-package
 ```
 
-### PyPI-to-conda conversion engine
+(pypi-to-conda-conversion-engine)=
+
+### Wheel-to-conda conversion engine
 
 `conda-pypi` includes a powerful conversion engine that enables direct
 conversion of pure Python wheels to `.conda` packages with proper translation of
 Python package metadata to conda format. The system includes name
-mapping of PyPI dependencies to conda equivalents and provides cross-platform
+mapping of Python distribution names to conda equivalents and provides cross-platform
 support for package conversion, ensuring that converted packages work
 across different operating systems and architectures.
 
@@ -141,7 +148,7 @@ checks `.dist-info/<path>` (pre-PEP 639 wheels) and `.dist-info/licenses/<path>`
 
 #### Dependency environment markers (PEP 508)
 
-PyPI [environment markers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers) are translated for the solver where possible. When building installable .conda packages from wheels, `[when="…"]` is not attached to dependency strings. The `extra == "…"` marker is split into per-extra tables, and other marker conditions are omitted from depends. See {doc}`developer/marker-conversion`.
+PEP 508 [environment markers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers) are translated for the solver where possible. When building installable .conda packages from wheels, `[when="…"]` is not attached to dependency strings. The `extra == "…"` marker is split into per-extra tables, and other marker conditions are omitted from depends. See {doc}`developer/marker-conversion`.
 
 ### Wheel channels
 
@@ -178,7 +185,7 @@ Wheels served this way behave like any other conda package.
 When a wheel is installed directly (from a wheel channel or a `.whl` file),
 conda-pypi writes `info/index.json` with:
 
-- `fn` — the wheel basename on disk (the PyPI upload filename), for example
+- `fn` — the wheel basename on disk, for example
   `requests-2.32.5-py3-none-any.whl`
 - `build` — from WHEEL `Tag` / `Build` headers (prefer `py3-none-any`, else highest
   tag). Noarch tags other than `py3-none-any` are normalized to `py3_none_any_0` to
@@ -223,7 +230,7 @@ conda pypi install -e ./package1/ -e ./package2/
 `conda-pypi` adds support for
 [PEP-668](https://peps.python.org/pep-0668/)'s
 [`EXTERNALLY-MANAGED`](https://packaging.python.org/en/latest/specifications/externally-managed-environments/)
-environment marker files. These files tell `pip` and other PyPI installers
+environment marker files. These files tell `pip` and other Python package installers
 not to install or remove any packages in that environment, guiding users
 towards safer alternatives.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 Welcome to the `conda-pypi` documentation!
 
 `conda-pypi` provides better PyPI interoperability for the conda ecosystem.
-It allows you to safely install PyPI packages in conda environments by
+It allows you to safely install Python distribution packages in conda environments by
 converting them to conda format when possible, while falling back to
 traditional pip installation when needed.
 
@@ -19,11 +19,12 @@ the tool makes pure Python packages from PyPI available through
 the `conda install` command, with no extra conversion needed.
 
 The tool also offers three commands for more advanced usage: `conda pypi install`
-for safer PyPI package installation with an intelligent hybrid approach,
-and `conda pypi convert` for converting PyPI packages to `.conda` format
-without installing them. The smart installation strategy ensures that
-explicitly requested packages come from PyPI while dependencies are sourced
-from conda channels when available. The `conda pypi index` command is provided
+for safer installation of Python distribution packages with an intelligent hybrid approach,
+and `conda pypi convert` for converting Python projects to `.conda` format
+without installing them. The installation strategy fetches missing wheels from
+PyPI and other package indexes while using packages from conda channels when available.
+PyPI is the default index, and `--index-url` selects an alternative for
+`conda pypi install`. The `conda pypi index` command is provided
 for indexing a local directory of `.whl` files to create a local conda channel.
 
 `conda-pypi` includes support for development workflows through editable

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -130,7 +130,8 @@ packages without using the `conda-pypi` channel. This method downloads missing
 wheels from PyPI and other package indexes and converts them to `.conda` format, then
 installs them. PyPI is the default index. Use `--index-url` to select another
 index for wheel downloads, including missing dependencies. Repeat the option
-to search multiple indexes. These replace the default PyPI index list.
+to search multiple indexes. Providing this option replaces the default PyPI
+index list.
 
 :::{note}
 These instructions assume that you have done the following:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -125,10 +125,12 @@ dependencies will be installed from conda rather than PyPI.
 The `conda pypi install` command is pending deprecation and will be removed in version 27.9. Use `conda install` with `conda-pypi` channel configuration instead.
 :::
 
-You can also use the `conda pypi` command to install packages from
-PyPI without using the `conda-pypi` channel. This method downloads
-the package from PyPI and converts it to `.conda` format, then installs
-it.
+You can also use the `conda pypi install` command to install Python distribution
+packages without using the `conda-pypi` channel. This method downloads missing
+wheels from PyPI and other package indexes and converts them to `.conda` format, then
+installs them. PyPI is the default index. Use `--index-url` to select another
+index for wheel downloads, including missing dependencies. Repeat the option
+to search multiple indexes. These replace the default PyPI index list.
 
 :::{note}
 These instructions assume that you have done the following:
@@ -142,34 +144,34 @@ conda pypi install build
 ```
 
 This will download and convert the `build` package from PyPI to `.conda`
-format. Even though `python-build` exists on conda, the explicitly requested
-package always comes from PyPI to ensure you get exactly what you asked for.
-However, its dependencies will preferentially come from conda channels when
+format if it is not already available from the configured conda channels or
+the local conversion cache.
+Its dependencies will preferentially come from conda channels when
 available.
 
 ```bash
 conda pypi install some-package-with-many-deps
 ```
 
-Here's where the hybrid approach really shines:
-`some-package-with-many-deps` itself will be converted from PyPI, but
-conda-pypi will analyze its dependency tree and:
+If `some-package-with-many-deps` is unavailable from the configured conda
+channels and the local conversion cache, it will be fetched from the configured
+package indexes and converted. For its dependencies, conda-pypi will:
+
 - Install dependencies like `numpy`, `pandas`, etc. from the conda channel (if
   available)
-- Convert only the dependencies that aren't available on conda channels from
-  PyPI
+- Fetch and convert missing wheels from the configured package indexes
 
 ```bash
 conda pypi install --ignore-channels some-package
 ```
 
-This command forces dependency resolution to use only PyPI, bypassing conda channel
-checks for dependencies. The requested package is always converted from PyPI
-regardless of this flag.
+This command bypasses the configured conda channels. Missing wheels are fetched
+from the configured package indexes, which default to PyPI. The local
+conversion cache remains available regardless of this flag.
 
 ### Converting packages without installing
 
-You can also convert PyPI packages to `.conda` format without installing
+You can also convert Python projects to `.conda` format without installing
 them:
 
 ```bash
@@ -180,7 +182,7 @@ conda pypi convert niquests rope
 conda pypi convert -d ./my_packages niquests rope
 ```
 
-This is useful for creating conda packages from PyPI distributions or
+This is useful for creating conda packages from Python distributions or
 preparing packages for offline installation.
 
 ### Indexing a local wheel directory
@@ -240,7 +242,7 @@ More details about this protection mechanism can be found at
 By default, `conda-pypi` displays a short tip when a conda transaction
 newly installs `pip` into an environment. The tip is not shown on `pip`
 upgrades, or on later installs into an environment that already has `pip`.
-It points to the conda-pypi docs for installing PyPI packages with conda.
+It points to the conda-pypi docs for installing packages from PyPI with conda.
 
 To disable this tip:
 

--- a/docs/reference/commands/convert.rst
+++ b/docs/reference/commands/convert.rst
@@ -13,7 +13,7 @@ Custom Name Mapping
 ===================
 
 The ``--name-mapping`` option allows you to provide a custom JSON file that maps
-PyPI package names to conda package names. This is useful when you need to
+Python distribution package names to conda package names. This is useful when you need to
 replace the built-in grayskull mapping with your own mapping file.
 
 When ``--name-mapping`` is provided, the built-in mapping is not used for that
@@ -21,7 +21,7 @@ conversion. The JSON file is treated as the complete mapping source.
 
 The mapping file should be a JSON object where:
 
-- Keys are PyPI package names (canonicalized, lowercase)
+- Keys are Python distribution package names (canonicalized, lowercase)
 - Values are dictionaries with at least a ``conda_name`` key (string)
 - Optionally can include ``pypi_name``, ``import_name``, and ``mapping_source`` keys
 

--- a/docs/reference/conda-channels-naming-analysis.md
+++ b/docs/reference/conda-channels-naming-analysis.md
@@ -15,7 +15,7 @@ the conda package name and the pypi name, the following analysis was done:
 # main_df: Pandas Dataframe from main channel
 # cf_df: Pandas Dataframe from conda-forge channel
 
-# Merging data by PyPi Name
+# Merging data by PyPI project name
 # main_df stores the package name as name and cf_df as conda_name so there is no collision
 mdf = pd.merge(main_df, cf_df, left_on="pypi_name", right_on="pypi_name")
 

--- a/docs/why/conda-packages-and-wheels.md
+++ b/docs/why/conda-packages-and-wheels.md
@@ -1,41 +1,48 @@
-# Key differences between conda and PyPI
+(key-differences-between-conda-and-pypi)=
 
-Below, we'll go over the two key differences between conda and PyPI packaging and why
+# Key differences between conda packages and wheels
+
+Below, we'll go over the two key differences between conda packages and wheels and why
 this leads to issues for users. The first problem is related to how binary distributions
 are packaged and distributed and the second problem is related to the package index
 and how each tool tracks what is currently installed.
 
+Wheels and source distributions are formats for
+[Python distribution packages](https://packaging.python.org/en/latest/discussions/distribution-package-vs-import-package/).
+PyPI is a package index that hosts these files. Tools such as pip install them.
+
 ## Summary
 
-- Conda and PyPI use different strategies for building binary distributions; when
+- Conda packages and wheels use different strategies for distributing binaries. When
   using these packaging formats together, it can lead to difficult to debug issues.
-- PyPI tools are aware of what is installed in a conda environment but when these
+- Python package installers such as pip are aware of what is installed in a conda environment but when these
   tools make changes to the environment conda loses track of what is installed.
 - conda relies on all packaging metadata (available packages, their dependencies, etc)
   being available upfront. PyPI only lists the available packages, but their dependencies
   need to be fetched on a package-per-package basis. This means that the solvers are
-  designed to work differently; a conda solver won't easily take the PyPI metadata
+  designed to work differently. A conda solver won't easily take the metadata from PyPI
   because it is not designed to work iteratively.
-- PyPI names are not always the same in a conda channel. They might have a different name,
+- Project names on PyPI are not always the same in a conda channel. They might have a different name,
   or use a different packaging approach altogether.
 
 ## Differences in binary distributions
 
-Conda and PyPI are separate packaging ecosystems with different packaging
-formats and philosophies. Conda distributes packages as .conda and .tar.bz2
+Conda packages and Python wheels have different formats and dependency
+conventions. Conda distributes packages as .conda and .tar.bz2
 files, which can include Python libraries and pre-compiled binaries with dynamic
-links to other dependencies. In contrast, PyPI provides .whl files (as defined
+links to other dependencies. In contrast, PyPI hosts wheel (.whl) files (as defined
 in [PEP 427](https://peps.python.org/pep-0427/)), which typically bundle all
-required binaries or rely on system-level dependencies, as it lacks support for
-non-Python dependency declarations [^1]. PyPI also supports source distributions,
+required binaries or rely on system-level dependencies. The `Requires-External`
+metadata field provides hints for downstream maintainers, rather than conda-style
+dependency resolution [^1]. PyPI also hosts source distributions,
 though these require building during installation.
 
 With that in mind, what are some potential ways this could break when combining the two
 ecosystems together? Because wheels typically include all of their pre-compiled binaries inside
 the wheel itself, this can lead to incompatibilities when used with conda packages containing
 pre-compiled binaries. In the conda ecosystem, these dependencies are normally tested with
-each other before being published during the build process, but the PyPI ecosystem does not test
-its wheels with conda packages and therefore users are typically the first to encounter these
+each other before being published during the build process, but wheels published on PyPI are not generally tested
+with conda packages and therefore users are typically the first to encounter these
 errors.
 
 Some examples of these incompatibilities include symbol errors, segfaults and other difficult to debug
@@ -73,7 +80,7 @@ and prone to errors this environment becomes.
 
 ## Package metadata differences
 
-PyPI and conda expose their packaging metadata in different ways, which results in their
+PyPI and other package indexes expose metadata differently from conda channels, which results in their
 solvers working differently too:
 
 In the conda ecosystem, packages are published to a *channel*. The metadata in
@@ -82,13 +89,13 @@ each package is extracted and aggregated into a per-platform JSON file
 packaging metadata needed for the solver to operate, and it's typically fetched
 and updated every time the user tries to install something.
 
-In PyPI, packages are published to an *index* following the Simple Repository
-API standard ([PEP 503](https://peps.python.org/pep-0503/)). The index provides
+Package indexes such as PyPI expose distribution files through the Simple
+Repository API standard ([PEP 503](https://peps.python.org/pep-0503/)). The index provides
 a list of all the available wheel files, with their filenames encoding some
 packaging metadata (like Python version and platform compatibility). Other
 metadata like the dependencies for that package need to be fetched on a
 per-wheel basis. As a result, the solver fetches metadata as it goes. Modern
-PyPI implementations can serve this index data in either HTML (the original PEP
+package indexes can serve this index data in either HTML (the original PEP
 503 format) or JSON ([PEP 691](https://peps.python.org/pep-0691/)) using HTTP
 content negotiation.
 
@@ -102,7 +109,7 @@ In a nutshell:
   ([PEP 691](https://peps.python.org/pep-0691/)) now provides more structured
   metadata access that reduces this need.
 - The conda solvers can work entirely from the aggregated metadata, while
-  PyPI-focused solvers have typically needed to fetch additional metadata as
+  solvers using package indexes have typically needed to fetch additional metadata as
   solutions are explored, though this pattern is evolving with newer API
   capabilities.
 
@@ -134,4 +141,4 @@ For an excellent overview of what a conda package actually is:
 
 - [What is a conda package? - prefix.dev](https://prefix.dev/blog/what-is-a-conda-package)
 
-[^1]: At least as of August 2025. Check [PEP 725](https://peps.python.org/pep-0725/) for a proposal external dependency metadata.
+[^1]: See [Requires-External](https://packaging.python.org/en/latest/specifications/core-metadata/#requires-external-multiple-use) and [PEP 725](https://peps.python.org/pep-0725/) for work on external dependency metadata.

--- a/docs/why/existing-strategies.md
+++ b/docs/why/existing-strategies.md
@@ -1,7 +1,7 @@
 # Existing strategies
 
 There are currently only a handful of patterns that are considered safe
-when installing PyPI packages inside a conda environment. We list these
+when installing Python distribution packages inside a conda environment. We list these
 scenarios below:
 
 ## Only install Python & pip inside conda environments
@@ -31,7 +31,9 @@ $ conda activate editable-install
 $ pip install -e . --no-deps
 ```
 
-## Package your PyPI dependencies as conda packages
+(package-your-pypi-dependencies-as-conda-packages)=
+
+## Package your Python dependencies as conda packages
 
 This is the safest option in terms of ensuring maximum stability, but it is
 also the most time-consuming. Maintaining a separate conda package can be a cumbersome

--- a/docs/why/index.md
+++ b/docs/why/index.md
@@ -1,15 +1,15 @@
 # Motivation and vision
 
-Although very common among conda users, using `conda` and PyPI (i.e. `pip`) together
+Although very common among conda users, using `conda` and `pip` in the same environment
 can under certain circumstances cause difficult to debug issues and is currently not
 seen as 100% stable. `conda-pypi` exists as a solution for creating a better experience
 when using these two packaging ecosystems together. Here, we give a high-level overview
 of why this conda plugin exists and finish by outlining our strategies for combining
-the use of both conda and PyPI.
+conda packages with Python distribution packages.
 
 ## The vision
 
-`conda-pypi` aims to make it easier and safer to add PyPI packages to existing conda environments.
+`conda-pypi` aims to make it easier and safer to add Python distribution packages to existing conda environments.
 We acknowledge that we cannot solve all problems, specifically as they relate to
 binary distributions of packages, but we believe we can provide users with a way to safely
 install pure Python packages in conda environments.
@@ -19,10 +19,10 @@ install pure Python packages in conda environments.
 To provide a thorough explanation of the problem and our proposed solutions, we have organized
 this section of the documentation into the following pages:
 
-- [Key Differences between conda and PyPI](conda-vs-pypi.md)
-  gives you a firm understanding of the problems that occur when using conda and PyPI together.
+- {doc}`Key differences between conda packages and wheels </why/conda-packages-and-wheels>`
+  gives you a firm understanding of the problems that occur when using conda packages and wheels together.
 - [Existing Strategies](existing-strategies.md) shows how users currently deal with
-  limitations of using conda and PyPI together.
+  limitations of using conda and pip together.
 - [Addressing these Issues with conda-pypi](potential-solutions.md)
   explains how this plugin can improve the user experience of mixing these two packaging
   ecosystems.
@@ -30,7 +30,7 @@ this section of the documentation into the following pages:
 ```{toctree}
 :hidden:
 
-conda-vs-pypi
+conda-packages-and-wheels
 existing-strategies
 potential-solutions
 ```

--- a/docs/why/potential-solutions.md
+++ b/docs/why/potential-solutions.md
@@ -20,18 +20,22 @@ no local conversion to the `.conda` format is needed.
 
 For setup instructions for the `conda-pypi` channel, see the {doc}`../quickstart`.
 
-## On-the-fly conversion of PyPI wheels to conda packages
+(on-the-fly-conversion-of-pypi-wheels-to-conda-packages)=
+
+## On-the-fly conversion of wheels to conda packages
 
 The inspiration for this approach initially started with the [conda-pupa](https://github.com/dholth/conda-pupa)
-project. The philosophy used here is that we can simply convert a wheel from PyPI into a conda
+project. The philosophy used here is that we can simply convert a wheel into a conda
 package and cache it on the host locally. In conda, it's straightforward to configure multiple channels
 to be used when installing packages, and by default, a "local" channel is included. As `conda-pypi`
-is run, it will begin transforming and caching wheels from PyPI into the conda packages which
+is run, it will begin transforming and caching wheels into the conda packages which
 are then saved in this local channel.
 
 This is the approach we currently feel most confident with implementing.
 
-## Analyze the dependency tree of your PyPI package
+(analyze-the-dependency-tree-of-your-pypi-package)=
+
+## Analyze the dependency tree of your Python distribution package
 
 In this approach, we run `pip` with the `--dry-run` option and analyze the proposed solution. Of those packages,
 we see which ones are already available on the configured conda channels and install them with `conda` proper.

--- a/news/docs-python-packaging-terminology
+++ b/news/docs-python-packaging-terminology
@@ -1,3 +1,3 @@
 ### Docs
 
-* Clarify terminology for distribution packages, package indexes, distribution formats, and package installers.
+* Clarify terminology for distribution packages, package indexes, distribution formats, and package installers. (#516)

--- a/news/docs-python-packaging-terminology
+++ b/news/docs-python-packaging-terminology
@@ -1,0 +1,3 @@
+### Docs
+
+* Clarify terminology for distribution packages, package indexes, distribution formats, and package installers.

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -43,7 +43,7 @@ def test_cli_plugin():
     pypi_subcommand = next((sub for sub in subcommands if sub.name == "pypi"), None)
 
     assert pypi_subcommand is not None
-    assert pypi_subcommand.summary == "Install PyPI packages as conda packages"
+    assert pypi_subcommand.summary == "Install Python distribution packages as conda packages"
     assert pypi_subcommand.action is not None
     assert pypi_subcommand.configure_parser is not None
 

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -25,7 +25,7 @@ def test_cli(conda_cli):
     # Help commands raise SystemExit, so we need to handle that
     out, _err, rc = conda_cli("pypi", "install", "--help", raises=SystemExit)
     assert rc.value.code == 0  # SystemExit(0) means success
-    assert "PyPI packages to install" in out
+    assert "Python distribution packages to install" in out
     assert "--dry-run" in out
     assert "--yes" in out
 


### PR DESCRIPTION
### Description

Clarify the distinction between distribution packages, wheels, package indexes, and package installers across the documentation and CLI help. Keep the public `conda-pypi` channel's scope explicit and describe `--index-url` support without implying that every requested package comes from PyPI.

Rename the comparison page to "Key differences between conda packages and wheels," preserving its previous URL through a redirect and retaining existing heading anchors.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] ~~Add / update necessary tests?~~
- [x] Add / update outdated documentation?
