### PR TITLE
Use conda-maintainers as default code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all files in the repository
-* @conda/conda-pypi
+* @conda/conda-maintainers


### PR DESCRIPTION
### Description

Use `@conda/conda-maintainers` as the default owner for all repository files so code owner review requests go to the conda maintainers team.

### Checklist - did you ...

- [x] ~~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?~~
- [x] ~~Add / update necessary tests?~~
- [x] ~~Add / update outdated documentation?~~
