### PR TITLE
Update recipe back to noarch

### DIFF
--- a/news/518-switch-recipe-noarch
+++ b/news/518-switch-recipe-noarch
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Switch the recipe back to Python noarch since the `EXTERNALLY_MANAGED` file isn't currently being used. (#518)

--- a/news/docs-python-packaging-terminology
+++ b/news/docs-python-packaging-terminology
@@ -1,3 +1,0 @@
-### Docs
-
-* Clarify terminology for distribution packages, package indexes, distribution formats, and package installers. (#516)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 
 build:
   # can't be noarch because we can't place EXTERNALLY-MANAGED in stdlib (first level is site-packages)
+  # However, EXTERNALLY-MANAGED is temporarily disabled, so go back to noarch
+  noarch: python
   number: 0
   script:
     - set -x  # [unix]
@@ -44,10 +46,6 @@ test:
     - conda_pypi.main
   commands:
     - python -m conda pypi --help
-    - python -c "from conda_pypi.python_paths import get_env_stdlib; assert (get_env_stdlib() / 'EXTERNALLY-MANAGED').exists()"
-    - python -c "from conda_pypi.python_paths import get_env_stdlib; content = (get_env_stdlib() / 'EXTERNALLY-MANAGED').read_text(); assert '[externally-managed]' in content"
-    - python -c "from conda_pypi.python_paths import get_env_stdlib; content = (get_env_stdlib() / 'EXTERNALLY-MANAGED').read_text(); assert 'conda pypi' in content"
-    - python -m pip install requests && exit 1 || exit 0
 
 about:
   home: https://github.com/conda/conda-pypi


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

In https://github.com/conda-forge/conda-pypi-feedstock/pull/67, we moved the recipe back to noarch since we aren't currently using the EXTERNALLY_MANAGED file. This updates the recipe to match.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-pypi/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pypi/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pypi/blob/main/CONTRIBUTING.md -->
